### PR TITLE
(FM-7444) conversion of network_trunk to agentless

### DIFF
--- a/examples/netdev/network_trunk.pp
+++ b/examples/netdev/network_trunk.pp
@@ -1,0 +1,11 @@
+network_trunk { 'ethernet1/4':
+    ensure        => 'present',
+    mode          => 'trunk',
+    tagged_vlans  => ['12', '16', '9', '3', '4', '6', '7', '8'],
+    untagged_vlan => 1;
+  'ethernet1/1':
+    ensure        => 'present',
+    mode          => 'trunk',
+    tagged_vlans  => ['12', '10', '9', '3', '4', '6', '7', '8'],
+    untagged_vlan => 1;
+}

--- a/lib/puppet/provider/network_trunk/cisco_nexus.rb
+++ b/lib/puppet/provider/network_trunk/cisco_nexus.rb
@@ -1,0 +1,111 @@
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the network_trunk type using the Resource API.
+class Puppet::Provider::NetworkTrunk::CiscoNexus < Puppet::ResourceApi::SimpleProvider
+  def canonicalize(_context, resources)
+    resources.each do |resource|
+      resource[:tagged_vlans] = resource[:tagged_vlans].sort_by(&:to_i) if resource[:tagged_vlans]
+    end
+    resources
+  end
+
+  def get(_context, interface_names=nil)
+    current_states = []
+    @interfaces ||= Cisco::Interface.interfaces
+    if interface_names.nil? || interface_names.empty?
+      @interfaces.each do |interface_name, instance|
+        get_interface(interface_name, instance, current_states)
+      end
+    else
+      interface_names.each do |interface_name|
+        get_interface(interface_name, @interfaces[interface_name], current_states)
+      end
+    end
+    current_states
+  end
+
+  def get_interface(name, interface, current_states)
+    return if interface.nil?
+    return unless interface.send(:switchport_mode) == :trunk 
+    array_vlans = convert_allowed_vlan_to_array(interface.send(:switchport_trunk_allowed_vlan))
+    current_states << {
+      name:          name,
+      untagged_vlan: interface.send(:switchport_trunk_native_vlan),
+      tagged_vlans:  array_vlans.sort_by(&:to_i),
+      mode:          'trunk',
+      ensure:        'present',
+    }
+  end
+
+  def update(context, name, should)
+    validate_should(should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+    @interfaces ||= Cisco::Interface.interfaces
+    @interfaces[name].switchport_mode = should[:mode].to_sym if should[:mode]
+    @interfaces[name].switchport_trunk_native_vlan = should[:untagged_vlan] if should[:untagged_vlan]
+    @interfaces[name].switchport_trunk_allowed_vlan = convert_array_to_allowed_vlan(should[:tagged_vlans]) if should[:tagged_vlans]
+  end
+
+  alias create update
+
+  def delete(context, name)
+    context.notice("Destroying '#{name}'")
+    @interfaces ||= Cisco::Interface.interfaces
+    @interfaces[name].destroy
+  end
+
+  # based on running commands against a NX-OS 9k device only
+  # 'access' and 'trunk' are supported switchport modes, and
+  # controlling of encapsulation does not seem possible, and
+  # there is no reference as to what pruned VLANS are with
+  # no indication on how to set/control them
+  def validate_should(should)
+    raise Puppet::ResourceError, "The mode `#{should[:mode]}` is not supported" if should[:mode] && !['access', 'trunk'].include?(should[:mode])
+    raise Puppet::ResourceError, 'VLAN-Tagging encapsulation is not supported on this device' if should[:encapsulation]
+    raise Puppet::ResourceError, 'VLAN pruning is not supported on this device' if should[:pruned_vlans]
+  end
+
+  # this converts from a cisco compatible comma separated range to an array of vlan_ids
+  # better to give an examples of how this works:
+  # 2-4,6-8 becomes [2,3,4,6,7,8]
+  def convert_allowed_vlan_to_array(allowed_vlan)
+    return_val = []
+    array_strings = allowed_vlan.split(',')
+    array_strings.each do |value|
+      # is a range ?
+      if value.include? '-'
+        range = value.split('-')
+        return_val.push(*(range.first..range.last).to_a)
+      else
+        return_val.push(value)
+      end
+    end
+    return_val.sort_by(&:to_i)
+  end
+
+  # this converts from an array of vlan_ids to a cisco compatible comma separated range
+  # better to give an examples, of how this works:
+  # [2,3,4,6,7,8] becomes 2-4,6-8
+  def convert_array_to_allowed_vlan(input)
+    # setting switchport_trunk_allowed_vlan to nil sets it to default range of 1-4094
+    return nil if input.empty?
+    return_val = ''
+    # take an array of vlan ids, and create an array  of ruby ranges
+    ranges = input.map(&:to_i).sort.uniq.reduce([]) do |spans, n|
+      if spans.empty? || spans.last.last != n.to_i - 1
+        spans + [n..n]
+      else
+        spans[0..-2] + [spans.last.first..n]
+      end
+    end
+    # loop over ranges and create a string of cisco ranges
+    ranges.each do |iter|
+      if iter.size == 1
+        return_val = return_val + iter.first.to_s + ','
+      else
+        return_val = return_val + iter.first.to_s + '-' + iter.last.to_s + ','
+      end
+    end
+    return_val = return_val.chomp(',')
+  end
+end

--- a/spec/unit/puppet/provider/network_trunk/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/network_trunk/cisco_nexus_spec.rb
@@ -1,0 +1,328 @@
+require 'spec_helper'
+require 'cisco_node_utils'
+
+ensure_module_defined('Puppet::Provider::NetworkTrunk')
+require 'puppet/provider/network_trunk/cisco_nexus'
+
+RSpec.describe Puppet::Provider::NetworkTrunk::CiscoNexus do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+  let(:device) { instance_double('Puppet::Util::NetworkDevice::Nexus::Device', 'device') }
+  let(:interface) { instance_double('Cisco::Interface', 'interface') }
+  let(:non_trunk) { instance_double('Cisco::Interface', 'non_trunk') }
+
+  before(:each) do
+    allow(context).to receive(:device).and_return(device)
+    allow(device).to receive(:facts).and_return('operatingsystem' => 'nexus')
+    allow(Cisco::Interface).to receive(:interfaces).and_return({})
+  end
+
+  describe '#get' do
+    context 'everything is empty' do
+      it 'still processes' do
+        expect(provider.get(context)).to eq []
+      end
+    end
+    context 'everything is not empty' do
+      it 'still processes' do
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface)
+        allow(interface).to receive(:send).with(:switchport_mode).and_return(:trunk)
+        allow(interface).to receive(:send).with(:switchport_trunk_allowed_vlan).and_return('2-3,6-10')
+        allow(interface).to receive(:send).with(:switchport_trunk_native_vlan).and_return(1)
+
+        expect(provider.get(context)).to eq [
+          {
+            ensure:        'present',
+            mode:          'trunk',
+            name:          'ethernet1',
+            tagged_vlans:  ['2', '3', '6', '7', '8', '9', '10'],
+            untagged_vlan: 1,
+          }
+        ]
+      end
+    end
+    context 'with non `trunk` interface' do
+      it 'still processes' do
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk)
+        allow(interface).to receive(:send).with(:switchport_mode).and_return(:trunk)
+        allow(non_trunk).to receive(:send).with(:switchport_mode).and_return(:access)
+        allow(interface).to receive(:send).with(:switchport_trunk_allowed_vlan).and_return('2-3,6-10')
+        allow(interface).to receive(:send).with(:switchport_trunk_native_vlan).and_return(1)
+
+        expect(provider.get(context)).to eq [
+          {
+            ensure:        'present',
+            mode:          'trunk',
+            name:          'ethernet1',
+            tagged_vlans:  ['2', '3', '6', '7', '8', '9', '10'],
+            untagged_vlan: 1,
+          }
+        ]
+      end
+    end
+    context 'with multiple `trunk` interface' do
+      it 'still processes' do
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk,
+                                                                   'ethernet3' => interface)
+        allow(interface).to receive(:send).with(:switchport_mode).and_return(:trunk)
+        allow(non_trunk).to receive(:send).with(:switchport_mode).and_return(:access)
+        allow(interface).to receive(:send).with(:switchport_trunk_allowed_vlan).and_return('2-3,6-10')
+        allow(interface).to receive(:send).with(:switchport_trunk_native_vlan).and_return(1)
+
+        expect(provider.get(context)).to eq [
+          {
+            ensure:        'present',
+            mode:          'trunk',
+            name:          'ethernet1',
+            tagged_vlans:  ['2', '3', '6', '7', '8', '9', '10'],
+            untagged_vlan: 1,
+          },
+          {
+            ensure:        'present',
+            mode:          'trunk',
+            name:          'ethernet3',
+            tagged_vlans:  ['2', '3', '6', '7', '8', '9', '10'],
+            untagged_vlan: 1,
+          }
+        ]
+      end
+    end
+    context 'get filter used without matches' do
+      it 'still processes' do
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk)
+        allow(interface).to receive(:send).with(:switchport_mode).and_return(:access)
+        allow(non_trunk).to receive(:send).with(:switchport_mode).and_return(:access)
+        allow(interface).to receive(:send).with(:switchport_trunk_allowed_vlan).and_return('2-3,6-10')
+        allow(interface).to receive(:send).with(:switchport_trunk_native_vlan).and_return(1)
+
+        expect(provider.get(context, ['ethernet1'])).to eq []
+      end
+    end
+    context 'get filter used with matches' do
+      it 'still processes' do
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk,
+                                                                   'ethernet23' => non_trunk)
+        allow(interface).to receive(:send).with(:switchport_mode).and_return(:trunk)
+        allow(non_trunk).to receive(:send).with(:switchport_mode).and_return(:trunk)
+        allow(interface).to receive(:send).with(:switchport_trunk_allowed_vlan).and_return('2-3,6-10')
+        allow(interface).to receive(:send).with(:switchport_trunk_native_vlan).and_return(1)
+
+        expect(provider.get(context, ['ethernet1'])).to eq [
+          {
+            ensure:        'present',
+            mode:          'trunk',
+            name:          'ethernet1',
+            tagged_vlans:  ['2', '3', '6', '7', '8', '9', '10'],
+            untagged_vlan: 1,
+          }
+        ]
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'update is called' do
+      let(:should_values) do
+        {
+          name:          'ethernet1',
+          ensure:        'present',
+          mode:          'trunk',
+          tagged_vlans:  ['2', '3', '4', '6', '7', '8'],
+          untagged_vlan: 1,
+        }
+      end
+
+      it 'performs an update' do
+        expect(context).to receive(:notice).with(%r{\AUpdating 'ethernet1'})
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk,
+                                                                   'ethernet23' => non_trunk)
+        allow(interface).to receive(:switchport_mode=).with(:trunk).and_return(interface)
+        allow(interface).to receive(:switchport_trunk_allowed_vlan=).with('2-4,6-8').and_return(interface)
+        allow(interface).to receive(:switchport_trunk_native_vlan=).with(1).and_return(interface)
+
+        provider.update(context, 'ethernet1', should_values)
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'create is called' do
+      let(:should_values) do
+        {
+          name:          'ethernet1',
+          ensure:        'present',
+          mode:          'trunk',
+          tagged_vlans:  ['2', '3', '4', '6', '7', '8'],
+          untagged_vlan: 1,
+        }
+      end
+
+      it 'creates an interface' do
+        expect(context).to receive(:notice).with(%r{\AUpdating 'ethernet1'})
+        allow(Cisco::Interface).to receive(:new).with('ethernet1')
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk,
+                                                                   'ethernet23' => non_trunk)
+        allow(interface).to receive(:switchport_mode=).with(:trunk).and_return(interface)
+        allow(interface).to receive(:switchport_trunk_allowed_vlan=).with('2-4,6-8').and_return(interface)
+        allow(interface).to receive(:switchport_trunk_native_vlan=).with(1).and_return(interface)
+
+        provider.create(context, 'ethernet1', should_values)
+      end
+    end
+  end
+
+  describe '#delete' do
+    context 'delete is called' do
+      it 'destroys an interface' do
+        expect(context).to receive(:notice).with(%r{\ADestroying 'ethernet1'})
+        allow(Cisco::Interface).to receive(:interfaces).and_return('ethernet1' => interface,
+                                                                   'ethernet2' => non_trunk,
+                                                                   'ethernet23' => non_trunk)
+        expect(interface).to receive(:destroy).and_return(interface).once
+        expect(non_trunk).to receive(:destroy).and_return(interface).never
+
+        provider.delete(context, 'ethernet1')
+      end
+    end
+  end
+
+  describe '#convert_allowed_vlan_to_array' do
+    context 'solo range is entered' do
+      it 'returns an ordered array' do
+        expect(provider.convert_allowed_vlan_to_array('1-6')).to eq ['1', '2', '3', '4', '5', '6']
+      end
+    end
+    context 'multi separate ranges are entered' do
+      it 'returns an ordered array' do
+        expect(provider.convert_allowed_vlan_to_array('1-3,6-9')).to eq ['1', '2', '3', '6', '7', '8', '9']
+      end
+    end
+    context 'range with extra entry' do
+      it 'returns an ordered array' do
+        expect(provider.convert_allowed_vlan_to_array('1-3,10')).to eq ['1', '2', '3', '10']
+      end
+    end
+  end
+
+  describe '#convert_array_to_allowed_vlan' do
+    context 'empty array is entered' do
+      it 'returns nil' do
+        expect(provider.convert_array_to_allowed_vlan([])).to eq nil
+      end
+    end
+    context 'array without ranges' do
+      it 'returns CSV list' do
+        expect(provider.convert_array_to_allowed_vlan(['1', '3', '5'])).to eq '1,3,5'
+      end
+    end
+    context 'array with ranges' do
+      it 'returns ranged list' do
+        expect(provider.convert_array_to_allowed_vlan(['1', '2', '3', '4', '5'])).to eq '1-5'
+      end
+    end
+    context 'array with separate ranges' do
+      it 'returns ranged list' do
+        expect(provider.convert_array_to_allowed_vlan(['1', '2', '3', '4', '5', '8', '9', '10'])).to eq '1-5,8-10'
+      end
+    end
+    context 'array with mixture of ranges and single values' do
+      it 'returns ranged list' do
+        expect(provider.convert_array_to_allowed_vlan(['1', '2', '3', '5', '8', '9', '10'])).to eq '1-3,5,8-10'
+      end
+    end
+  end
+
+  canonicalize_data = [
+    {
+      desc: '`resources` already sorted',
+      resources: [{
+        name:         'ethernet1',
+        ensure:       'present',
+        tagged_vlans: ['1', '2', '3', '10'],
+      }],
+      results: [{
+        name:         'ethernet1',
+        ensure:       'present',
+        tagged_vlans: ['1', '2', '3', '10'],
+      }],
+    },
+    {
+      desc: '`resources` requires sorting',
+      resources: [{
+        name:         'ethernet1',
+        ensure:       'present',
+        tagged_vlans: ['10', '2', '3', '1'],
+      }],
+      results: [{
+        name:         'ethernet1',
+        ensure:       'present',
+        tagged_vlans: ['1', '2', '3', '10'],
+      }],
+    },
+    {
+      desc: '`resources` does not contain `tagged_vlans`',
+      resources: [{
+        name:         'ethernet1',
+        ensure:       'present',
+      }],
+      results: [{
+        name:         'ethernet1',
+        ensure:       'present',
+      }],
+    },
+  ]
+
+  describe '#canonicalize' do
+    canonicalize_data.each do |test|
+      context "#{test[:desc]}" do
+        it 'returns canonicalized resource' do
+          expect(provider.canonicalize(context, test[:resources])).to eq(test[:results])
+        end
+      end
+    end
+  end
+
+  describe '#validate_should' do
+    context 'invalid modes entered' do
+      it { expect { provider.validate_should(mode: 'dynamic_auto') }.to raise_error Puppet::ResourceError, 'The mode `dynamic_auto` is not supported' }
+      it { expect { provider.validate_should(mode: 'dynamic_desirable') }.to raise_error Puppet::ResourceError, 'The mode `dynamic_desirable` is not supported' }
+      it { expect { provider.validate_should(mode: 'foo') }.to raise_error Puppet::ResourceError, 'The mode `foo` is not supported' }
+      it { expect { provider.validate_should(mode: '') }.to raise_error Puppet::ResourceError, 'The mode `` is not supported' }
+    end
+    context 'valid modes entered' do
+      it { expect { provider.validate_should(mode: 'access') }.not_to raise_error }
+      it { expect { provider.validate_should(mode: 'trunk') }.not_to raise_error }
+    end
+    context 'encapsulation key entered/present' do
+      it { expect { provider.validate_should(encapsulation: 'negotiate') }.to raise_error Puppet::ResourceError, 'VLAN-Tagging encapsulation is not supported on this device' }
+      it { expect { provider.validate_should(encapsulation: 'dot1q') }.to raise_error Puppet::ResourceError, 'VLAN-Tagging encapsulation is not supported on this device' }
+      it { expect { provider.validate_should(encapsulation: 'isl') }.to raise_error Puppet::ResourceError, 'VLAN-Tagging encapsulation is not supported on this device' }
+      it { expect { provider.validate_should(encapsulation: '') }.to raise_error Puppet::ResourceError, 'VLAN-Tagging encapsulation is not supported on this device' }
+    end
+    context 'pruned_vlans key entered/present' do
+      it { expect { provider.validate_should(pruned_vlans: ['1', '2']) }.to raise_error Puppet::ResourceError, 'VLAN pruning is not supported on this device' }
+      it { expect { provider.validate_should(pruned_vlans: []) }.to raise_error Puppet::ResourceError, 'VLAN pruning is not supported on this device' }
+      it { expect { provider.validate_should(pruned_vlans: '') }.to raise_error Puppet::ResourceError, 'VLAN pruning is not supported on this device' }
+    end
+    context 'valid should' do
+      let(:should_values) do
+        {
+          name:          'ethernet1',
+          ensure:        'present',
+          mode:          'trunk',
+          tagged_vlans:  ['2', '3', '4', '6', '7', '8'],
+          untagged_vlan: 1,
+        }
+      end
+
+      it { expect { provider.validate_should(should_values) }.not_to raise_error }
+    end
+  end
+end

--- a/tests/beaker_tests/network_trunk/test_network_trunk.rb
+++ b/tests/beaker_tests/network_trunk/test_network_trunk.rb
@@ -27,9 +27,7 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 tests = {
   agent:            agent,
   master:           master,
-  ensurable:        false,
   intf_type:        'ethernet',
-  operating_system: 'nexus',
   resource_name:    'network_trunk',
 }
 
@@ -37,7 +35,7 @@ tests = {
 intf = find_interface(tests)
 
 # Test hash test cases
-tagged_manifest = [2, 3, 4, 6, 7, 8]
+tagged_manifest = ['2', '3', '4', '6', '7', '8']
 tagged_resource = %w(2 3 4 6 7 8)
 tests[:non_default] = {
   desc:           '2. Non Default',


### PR DESCRIPTION
Network trunk is a netdev_stdlib type that would require the use of RSAPI's canonicalize feature, which means this change is dependent on MODULES-8070 getting completed first.