### PR TITLE
(FM-7109) Add apply_to_all to types for dual mode

### DIFF
--- a/lib/puppet/type/cisco_aaa_authentication_login.rb
+++ b/lib/puppet/type/cisco_aaa_authentication_login.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an SNMP server.
 #
-# November 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ Puppet::Type.newtype(:cisco_aaa_authentication_login) do
       mschapv2               => false,
     }
 ~~~"
+
+  apply_to_all
 
   ###################
   # Resource Naming #

--- a/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
@@ -1,8 +1,8 @@
 # Manages configuration for Aaa Authorization Login Config Service.
 #
-# December 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_cfg_svc) do
     }
 ~~~"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -1,8 +1,8 @@
 # Manages execuration for Aaa Authorization Login Exec Service.
 #
-# December 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
     }
 ~~~"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_aaa_group_tacacs.rb
+++ b/lib/puppet/type/cisco_aaa_group_tacacs.rb
@@ -1,8 +1,8 @@
 # Manages configuration for a TACACS+ server group.
 #
-# October 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ Puppet::Type.newtype(:cisco_aaa_group_tacacs) do
       vrf_name         => \"blue\",
     }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_ace.rb
+++ b/lib/puppet/type/cisco_ace.rb
@@ -1,8 +1,8 @@
 # Manages configuration for cisco_ace
 #
-# January 2016
+# June 2018
 #
-# Copyright (c) 2018 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ Puppet::Type.newtype(:cisco_ace) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the acl_name method which by default returns only

--- a/lib/puppet/type/cisco_acl.rb
+++ b/lib/puppet/type/cisco_acl.rb
@@ -1,7 +1,9 @@
 #
 # Puppet resource type for cisco_acl
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,6 +64,7 @@ Puppet::Type.newtype(:cisco_acl) do
   ~~~
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_bfd_global.rb
+++ b/lib/puppet/type/cisco_bfd_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Bfd Global configuration resource.
 #
-# May 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ Puppet::Type.newtype(:cisco_bfd_global) do
     }
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_bgp.rb
+++ b/lib/puppet/type/cisco_bgp.rb
@@ -1,8 +1,8 @@
 # Manages BGP global and vrf configuration.
 #
-# July 2015
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -149,6 +149,7 @@ Puppet::Type.newtype(:cisco_bgp) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only

--- a/lib/puppet/type/cisco_bgp_af.rb
+++ b/lib/puppet/type/cisco_bgp_af.rb
@@ -1,7 +1,9 @@
 #
 # Manages BGP Address-Family configuration.
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -168,6 +170,7 @@ Puppet::Type.newtype(:cisco_bgp_af) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only

--- a/lib/puppet/type/cisco_bgp_af_aa.rb
+++ b/lib/puppet/type/cisco_bgp_af_aa.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Bgp_af_aa configuration resource.
 #
-# May 2017
+# June 2018
 #
-# Copyright (c) 2017 Cisco and/or its affiliates.
+# Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ Example:
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only

--- a/lib/puppet/type/cisco_bgp_neighbor.rb
+++ b/lib/puppet/type/cisco_bgp_neighbor.rb
@@ -1,8 +1,8 @@
 # Puppet type that manages BGP Neighbor configuration.
 #
-# September 2015
+# June 2018
 #
-# Copyright (c) 2015 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,6 +140,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only

--- a/lib/puppet/type/cisco_bgp_neighbor_af.rb
+++ b/lib/puppet/type/cisco_bgp_neighbor_af.rb
@@ -1,8 +1,8 @@
 # Manages BGP Neighbor Address-Family configuration.
 #
-# August 2015
+# June 2018
 #
-# Copyright (c) 2015 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -190,6 +190,7 @@ Puppet::Type.newtype(:cisco_bgp_neighbor_af) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only

--- a/lib/puppet/type/cisco_bridge_domain.rb
+++ b/lib/puppet/type/cisco_bridge_domain.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco Bridge Domain.
 #
-# March 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ Puppet::Type.newtype(:cisco_bridge_domain) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:bd_name) do

--- a/lib/puppet/type/cisco_bridge_domain_vni.rb
+++ b/lib/puppet/type/cisco_bridge_domain_vni.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco Bridge Domain.
 #
-# March 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ Puppet::Type.newtype(:cisco_bridge_domain_vni) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:member_vni) do

--- a/lib/puppet/type/cisco_command_config.rb
+++ b/lib/puppet/type/cisco_command_config.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco network element that it connects to.
 #
-# September, 2013
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,6 +65,8 @@ Puppet::Type.newtype(:cisco_command_config) do
 
   <require> is optional.
   "
+
+  apply_to_all
 
   ###################
   # Resource Naming #

--- a/lib/puppet/type/cisco_dhcp_relay_global.rb
+++ b/lib/puppet/type/cisco_dhcp_relay_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Spanning-tree Global configuration resource.
 #
-# September 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ Puppet::Type.newtype(:cisco_dhcp_relay_global) do
       ipv6_src_intf                     => 'vlan2',
     }
   "
+
+  apply_to_all
+
   ###################
   # Resource Naming #
   ###################

--- a/lib/puppet/type/cisco_encapsulation.rb
+++ b/lib/puppet/type/cisco_encapsulation.rb
@@ -1,7 +1,7 @@
 #
-# March 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ Puppet::Type.newtype(:cisco_encapsulation) do
   # Properties #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:dot1q_map, array_matching: :all) do

--- a/lib/puppet/type/cisco_evpn_multicast.rb
+++ b/lib/puppet/type/cisco_evpn_multicast.rb
@@ -1,7 +1,7 @@
 #
-# February 2018
+# June 2018
 #
-# Copyright (c) 2018-2019 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,5 +67,6 @@ Puppet::Type.newtype(:cisco_evpn_multicast) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 end # Puppet::Type.newtype

--- a/lib/puppet/type/cisco_evpn_multisite.rb
+++ b/lib/puppet/type/cisco_evpn_multisite.rb
@@ -1,5 +1,5 @@
 #
-# December 2017
+# June 2018
 #
 # Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
@@ -51,6 +51,7 @@ Puppet::Type.newtype(:cisco_evpn_multisite) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:delay_restore) do

--- a/lib/puppet/type/cisco_evpn_stormcontrol.rb
+++ b/lib/puppet/type/cisco_evpn_stormcontrol.rb
@@ -1,5 +1,5 @@
 #
-# December 2017
+# June 2018
 #
 # Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
@@ -48,6 +48,7 @@ Puppet::Type.newtype(:cisco_evpn_stormcontrol) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:level) do

--- a/lib/puppet/type/cisco_evpn_vni.rb
+++ b/lib/puppet/type/cisco_evpn_vni.rb
@@ -1,7 +1,7 @@
 #
-# December 2015
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ Puppet::Type.newtype(:cisco_evpn_vni) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:route_distinguisher) do

--- a/lib/puppet/type/cisco_fabricpath_global.rb
+++ b/lib/puppet/type/cisco_fabricpath_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Fabricpath Global configuration resource.
 #
-# February, 2016
+# June 2018
 #
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ Puppet::Type.newtype(:cisco_fabricpath_global) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:aggregate_multicast_routes) do

--- a/lib/puppet/type/cisco_fabricpath_topology.rb
+++ b/lib/puppet/type/cisco_fabricpath_topology.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco fabricpath Topology.
 #
-# February, 2016
+# June 2018
 #
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ Puppet::Type.newtype(:cisco_fabricpath_topology) do
 
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_hsrp_global.rb
+++ b/lib/puppet/type/cisco_hsrp_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Hsrp Global configuration resource.
 #
-# October 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ Puppet::Type.newtype(:cisco_hsrp_global) do
       extended_hold          => 200,
     }
   "
+
+  apply_to_all
+
   ###################
   # Resource Naming #
   ###################

--- a/lib/puppet/type/cisco_interface.rb
+++ b/lib/puppet/type/cisco_interface.rb
@@ -1,6 +1,6 @@
 # Manages a Cisco Network Interface.
 #
-# May 2013
+# June 2018
 #
 # Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
@@ -149,6 +149,7 @@ Puppet::Type.newtype(:cisco_interface) do
   # Basic / L2 Configuration Attributes #
   #######################################
 
+  apply_to_all
   ensurable
 
   newproperty(:bfd_echo) do

--- a/lib/puppet/type/cisco_interface_capabilities.rb
+++ b/lib/puppet/type/cisco_interface_capabilities.rb
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
+# June 2018
 # April 2016, Chris Van Heuveln
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +31,8 @@ end
 
 Puppet::Type.newtype(:cisco_interface_capabilities) do
   @doc = 'Interface capabilities utility. This is a test-only resource.'
+
+  apply_to_all
 
   newparam(:name, namevar: :true) do
     munge(&:downcase)

--- a/lib/puppet/type/cisco_interface_channel_group.rb
+++ b/lib/puppet/type/cisco_interface_channel_group.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco Network Interface Channel Group.
 #
-# January 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ Puppet::Type.newtype(:cisco_interface_channel_group) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:channel_group) do

--- a/lib/puppet/type/cisco_interface_evpn_multisite.rb
+++ b/lib/puppet/type/cisco_interface_evpn_multisite.rb
@@ -1,5 +1,5 @@
 #
-# December 2017
+# June 2018
 #
 # Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
@@ -56,6 +56,7 @@ Puppet::Type.newtype(:cisco_interface_evpn_multisite) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:tracking) do

--- a/lib/puppet/type/cisco_interface_hsrp_group.rb
+++ b/lib/puppet/type/cisco_interface_hsrp_group.rb
@@ -56,6 +56,7 @@ Puppet::Type.newtype(:cisco_interface_hsrp_group) do
     }
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_interface_ospf.rb
+++ b/lib/puppet/type/cisco_interface_ospf.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an ospf interface instance
 #
-# March 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ Puppet::Type.newtype(:cisco_interface_ospf) do
       transmit_delay                 => 300,
     }"
 
+  apply_to_all
   ensurable
 
   # Parse out the title to fill in the attributes in these

--- a/lib/puppet/type/cisco_interface_portchannel.rb
+++ b/lib/puppet/type/cisco_interface_portchannel.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco PortChannel Interface.
 #
-# Dec 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ Puppet::Type.newtype(:cisco_interface_portchannel) do
   # Attributes #
   #######################################
 
+  apply_to_all
   ensurable
 
   newproperty(:bfd_per_link) do

--- a/lib/puppet/type/cisco_interface_service_vni.rb
+++ b/lib/puppet/type/cisco_interface_service_vni.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco Network Interface Service VNI
 #
-# January 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ Puppet::Type.newtype(:cisco_interface_service_vni) do
     patterns
   end
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only self[:name]

--- a/lib/puppet/type/cisco_ip_multicast.rb
+++ b/lib/puppet/type/cisco_ip_multicast.rb
@@ -1,7 +1,7 @@
 #
-# February 2018
+# June 2018
 #
-# Copyright (c) 2018-2019 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ Puppet::Type.newtype(:cisco_ip_multicast) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:overlay_distributed_dr) do

--- a/lib/puppet/type/cisco_itd_device_group.rb
+++ b/lib/puppet/type/cisco_itd_device_group.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco ItdDeviceGroup.
 #
-# Feb 2016
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ Puppet::Type.newtype(:cisco_itd_device_group) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:probe_control) do

--- a/lib/puppet/type/cisco_itd_device_group_node.rb
+++ b/lib/puppet/type/cisco_itd_device_group_node.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco ItdDeviceGroupNode.
 #
-# Feb 2016
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,6 +94,7 @@ Puppet::Type.newtype(:cisco_itd_device_group_node) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:hot_standby) do

--- a/lib/puppet/type/cisco_itd_service.rb
+++ b/lib/puppet/type/cisco_itd_service.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco Itd Service.
 #
-# March 2016
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ Puppet::Type.newtype(:cisco_itd_service) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:access_list) do

--- a/lib/puppet/type/cisco_object_group.rb
+++ b/lib/puppet/type/cisco_object_group.rb
@@ -1,7 +1,9 @@
 #
 # Puppet resource type for cisco_object_group
 #
-# Copyright (c) 2017 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +46,7 @@ Puppet::Type.newtype(:cisco_object_group) do
   ~~~
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_object_group_entry.rb
+++ b/lib/puppet/type/cisco_object_group_entry.rb
@@ -1,8 +1,8 @@
 # Manages configuration for cisco_object_group_entry
 #
-# June 2017
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,8 @@ Puppet::Type.newtype(:cisco_object_group_entry) do
     }
   ~~~
   "
+
+  apply_to_all
 
   ###################
   # Resource Naming #

--- a/lib/puppet/type/cisco_ospf.rb
+++ b/lib/puppet/type/cisco_ospf.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an ospf instance
 #
-# March 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ Puppet::Type.newtype(:cisco_ospf) do
       ensure => present,
     }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_ospf_area.rb
+++ b/lib/puppet/type/cisco_ospf_area.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco OSPF area configuration resource.
 #
-# June 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ Puppet::Type.newtype(:cisco_ospf_area) do
     }
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_ospf_area_vlink.rb
+++ b/lib/puppet/type/cisco_ospf_area_vlink.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco OSPF area virtual-link configuration resource.
 #
-# June 2016
+# June 2018
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ Puppet::Type.newtype(:cisco_ospf_area_vlink) do
     }
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_ospf_vrf.rb
+++ b/lib/puppet/type/cisco_ospf_vrf.rb
@@ -1,8 +1,8 @@
 # Manages a VRF for OSPF.
 #
-# March 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ Puppet::Type.newtype(:cisco_ospf_vrf) do
       auto_cost                => 40000,
   }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_overlay_global.rb
+++ b/lib/puppet/type/cisco_overlay_global.rb
@@ -2,9 +2,9 @@
 # Duplicate host IP address detection, duplicate host mac address
 # detection and configuring anycast gateway mac address.
 #
-# November 2015
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ Puppet::Type.newtype(:cisco_overlay_global) do
     }
   ~~~
   "
+
+  apply_to_all
 
   newparam(:name, namevar: :true) do
     desc "Instance of overlay_global, only allow the value 'default'"

--- a/lib/puppet/type/cisco_pim.rb
+++ b/lib/puppet/type/cisco_pim.rb
@@ -1,7 +1,9 @@
 #
 # Puppet resource type for pim
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,6 +80,7 @@ Puppet::Type.newtype(:cisco_pim) do
   ~~~
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_pim_grouplist.rb
+++ b/lib/puppet/type/cisco_pim_grouplist.rb
@@ -1,7 +1,9 @@
 #
 # Puppet resource type for pim
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,6 +85,8 @@ Puppet::Type.newtype(:cisco_pim_grouplist) do
     }
   ~~~
   "
+
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_pim_rp_address.rb
+++ b/lib/puppet/type/cisco_pim_rp_address.rb
@@ -1,7 +1,9 @@
 #
 # Puppet resource type for pim
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +72,8 @@ Puppet::Type.newtype(:cisco_pim_rp_address) do
     }
   ~~~
   "
+
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_portchannel_global.rb
+++ b/lib/puppet/type/cisco_portchannel_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco PortChannel Global configuration resource.
 #
-# Dec 2015
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,9 @@ Puppet::Type.newtype(:cisco_portchannel_global) do
       symmetry                       => 'true',
     }
   "
+
+  apply_to_all
+
   ###################
   # Resource Naming #
   ###################

--- a/lib/puppet/type/cisco_route_map.rb
+++ b/lib/puppet/type/cisco_route_map.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco route map configuration resource.
 #
-# January 2017
+# June 2018
 #
-# Copyright (c) 2017 Cisco and/or its affiliates.
+# Copyright (c) 2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -152,6 +152,7 @@ Puppet::Type.newtype(:cisco_route_map) do
     }
   "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_snmp_community.rb
+++ b/lib/puppet/type/cisco_snmp_community.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an SNMP server.
 #
-# December 2013
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ Puppet::Type.newtype(:cisco_snmp_community) do
       acl       => \"testcomacl\",
     }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_snmp_group.rb
+++ b/lib/puppet/type/cisco_snmp_group.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an SNMP group.
 #
-# January 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ Puppet::Type.newtype(:cisco_snmp_group) do
       ensure      => present,
     }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_snmp_server.rb
+++ b/lib/puppet/type/cisco_snmp_server.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an SNMP server.
 #
-# December 2013
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ Puppet::Type.newtype(:cisco_snmp_server) do
       protocol               => false,
       global_enforce_priv    => false,
     }"
+
+  apply_to_all
 
   ###################
   # Resource Naming #

--- a/lib/puppet/type/cisco_snmp_user.rb
+++ b/lib/puppet/type/cisco_snmp_user.rb
@@ -1,8 +1,8 @@
 # Manages configuration for an SNMP user.
 #
-# January 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ Puppet::Type.newtype(:cisco_snmp_user) do
       localized_key => false,
      } "
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_stp_global.rb
+++ b/lib/puppet/type/cisco_stp_global.rb
@@ -1,8 +1,8 @@
 # Manages the Cisco Spanning-tree Global configuration resource.
 #
-# Jan 2016
+# June 2018
 #
-# Copyright (c) 2013-2015 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,6 +63,9 @@ Puppet::Type.newtype(:cisco_stp_global) do
       vlan_root_priority           => [['1-42', '40960'], ['83-92,1000-2300', '53248']],
     }
   "
+
+  apply_to_all
+
   ###################
   # Resource Naming #
   ###################

--- a/lib/puppet/type/cisco_tacacs_server.rb
+++ b/lib/puppet/type/cisco_tacacs_server.rb
@@ -1,7 +1,7 @@
 ##############################################
 # Manages configuration for an TACACS server.
 #
-# March 2014
+# June 2018
 #
 # Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
@@ -63,6 +63,7 @@ Puppet::Type.newtype(:cisco_tacacs_server) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newparam(:name, namevar: :true) do

--- a/lib/puppet/type/cisco_tacacs_server_host.rb
+++ b/lib/puppet/type/cisco_tacacs_server_host.rb
@@ -1,6 +1,6 @@
 # Manages a Cisco Tacacs Server Host.
 #
-# March 2014
+# June 2018
 #
 # Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
@@ -34,6 +34,7 @@ Puppet::Type.newtype(:cisco_tacacs_server_host) do
       encryption_password => 'xxxxx',
     }"
 
+  apply_to_all
   ensurable
 
   ###################

--- a/lib/puppet/type/cisco_upgrade.rb
+++ b/lib/puppet/type/cisco_upgrade.rb
@@ -1,7 +1,9 @@
 #
 # Manages the version of Cisco Image running on a device.
 #
-# Copyright (c) 2017 Cisco and/or its affiliates.
+# June 2018
+#
+# Copyright (c) 2017-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +37,8 @@ Puppet::Type.newtype(:cisco_upgrade) do
     }
   ```
   "
+
+  apply_to_all
 
   # Parse out the title to fill in the attributes in these
   # patterns. These attributes can be overwritten later.

--- a/lib/puppet/type/cisco_vdc.rb
+++ b/lib/puppet/type/cisco_vdc.rb
@@ -1,8 +1,9 @@
 # Manages VDC configuration.
 #
+# June 2018
 # January 2016, Chris Van Heuveln
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,6 +66,7 @@ Puppet::Type.newtype(:cisco_vdc) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/cisco_vlan.rb
+++ b/lib/puppet/type/cisco_vlan.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco VLAN.
 #
-# April 2013
+# June 2018
 #
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ Puppet::Type.newtype(:cisco_vlan) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:vlan_name) do

--- a/lib/puppet/type/cisco_vpc_domain.rb
+++ b/lib/puppet/type/cisco_vpc_domain.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco VPC domain object
 #
-# January 2016
+# June 2018
 #
-# Copyright (c) 2013-2017 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -103,6 +103,7 @@ Puppet::Type.newtype(:cisco_vpc_domain) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:auto_recovery) do

--- a/lib/puppet/type/cisco_vrf.rb
+++ b/lib/puppet/type/cisco_vrf.rb
@@ -1,8 +1,8 @@
 # Manages a Cisco VRF.
 #
-# July 2015
+# June 2018
 #
-# Copyright (c) 2015-2016 Cisco and/or its affiliates.
+# Copyright (c) 2015-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ Puppet::Type.newtype(:cisco_vrf) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:description) do

--- a/lib/puppet/type/cisco_vrf_af.rb
+++ b/lib/puppet/type/cisco_vrf_af.rb
@@ -1,8 +1,9 @@
 # Manage a Cisco VRF Address-Family.
 #
+# June 2018
 # January 2016, Chris Van Heuveln
 #
-# Copyright (c) 2016 Cisco and/or its affiliates.
+# Copyright (c) 2016-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -146,6 +147,7 @@ Puppet::Type.newtype(:cisco_vrf_af) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:route_policy_export) do

--- a/lib/puppet/type/cisco_vtp.rb
+++ b/lib/puppet/type/cisco_vtp.rb
@@ -1,8 +1,8 @@
 # Manages the VTP configuration of a Cisco Device.
 #
-# January 2014
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ Puppet::Type.newtype(:cisco_vtp) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   newproperty(:domain) do

--- a/lib/puppet/type/cisco_vxlan_vtep.rb
+++ b/lib/puppet/type/cisco_vxlan_vtep.rb
@@ -1,8 +1,8 @@
 # Manages VXLAN vtep nve interface configuration.
 #
-# December 2015
+# June 2018
 #
-# Copyright (c) 2014-2015 Cisco and/or its affiliates.
+# Copyright (c) 2014-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ Puppet::Type.newtype(:cisco_vxlan_vtep) do
   # Parameters #
   ##############
 
+  apply_to_all
   ensurable
 
   newparam(:interface, namevar: :true) do

--- a/lib/puppet/type/cisco_vxlan_vtep_vni.rb
+++ b/lib/puppet/type/cisco_vxlan_vtep_vni.rb
@@ -1,9 +1,9 @@
 # Manages a Cisco Virtual Tunnel Endpoint (VTEP) to Virtual Network
 # Identifier (VNI) binding.
 #
-# January 2016
+# June 2018
 #
-# Copyright (c) 2013-2016 Cisco and/or its affiliates.
+# Copyright (c) 2013-2018 Cisco and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -109,6 +109,7 @@ Puppet::Type.newtype(:cisco_vxlan_vtep_vni) do
   # Attributes #
   ##############
 
+  apply_to_all
   ensurable
 
   # Overwrites the name method which by default returns only self[:name].


### PR DESCRIPTION
This commit adds `apply_to_all` to the types.  This will allow us to support both agent and Puppet Device