### PR TITLE
(FM-7550) changing test_harness_run logic

### DIFF
--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -135,40 +135,43 @@ tests[:seq_50_icmp_v4] = {
     vlan:         '100',
   },
 }
-# Overridden to properly handle unsupported properties for this test file.
-def unsupported_properties(tests, id)
-  unprops = []
 
-  if operating_system == 'ios_xr'
-    # unprops << TBD: XR Support
+# class to contain the test_dependencies specific to this test case
+class TestAce
+  def self.unsupported_properties(tests, id)
+    unprops = []
 
-  else
-    if tests[id][:title_pattern][/ipv6/]
-      unprops <<
-        :http_method <<
-        :precedence <<
-        :redirect <<
-        :tcp_option_length
+    if operating_system == 'ios_xr'
+      # unprops << TBD: XR Support
+
+    else
+      if tests[id][:title_pattern][/ipv6/]
+        unprops <<
+          :http_method <<
+          :precedence <<
+          :redirect <<
+          :tcp_option_length
+      end
+      if platform[/n(5|6)k/]
+        unprops <<
+          :proto_option <<
+          :packet_length <<
+          :time_range
+      end
+      if platform[/n(5|6|7)k/]
+        unprops <<
+          :http_method <<
+          :redirect <<
+          :vlan <<
+          :tcp_option_length <<
+          :set_erspan_dscp <<
+          :set_erspan_gre_proto <<
+          :ttl
+      end
     end
-    if platform[/n(5|6)k/]
-      unprops <<
-        :proto_option <<
-        :packet_length <<
-        :time_range
-    end
-    if platform[/n(5|6|7)k/]
-      unprops <<
-        :http_method <<
-        :redirect <<
-        :vlan <<
-        :tcp_option_length <<
-        :set_erspan_dscp <<
-        :set_erspan_gre_proto <<
-        :ttl
-    end
+
+    unprops
   end
-
-  unprops
 end
 
 #################################################################
@@ -181,14 +184,14 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # ---------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. ACE Testing")
 
-  test_harness_run(tests, :seq_5_remark)
-  test_harness_run(tests, :seq_10_v4)
-  test_harness_run(tests, :seq_10_v6)
-  test_harness_run(tests, :seq_20_v4)
-  test_harness_run(tests, :seq_20_v6)
-  test_harness_run(tests, :seq_30_v4)
-  test_harness_run(tests, :seq_40_icmp_v4)
-  test_harness_run(tests, :seq_50_icmp_v4)
+  test_harness_run(tests, :seq_5_remark, harness_class: TestAce)
+  test_harness_run(tests, :seq_10_v4, harness_class: TestAce)
+  test_harness_run(tests, :seq_10_v6, harness_class: TestAce)
+  test_harness_run(tests, :seq_20_v4, harness_class: TestAce)
+  test_harness_run(tests, :seq_20_v6, harness_class: TestAce)
+  test_harness_run(tests, :seq_30_v4, harness_class: TestAce)
+  test_harness_run(tests, :seq_40_icmp_v4, harness_class: TestAce)
+  test_harness_run(tests, :seq_50_icmp_v4, harness_class: TestAce)
 
   # ---------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_acl/test_acl.rb
+++ b/tests/beaker_tests/cisco_acl/test_acl.rb
@@ -75,18 +75,20 @@ tests[:title_patterns_3] = {
   resource:       { 'ensure' => 'present' },
 }
 
-# Overridden to properly handle unsupported properties for this test file.
-def unsupported_properties(_tests, _id)
-  unprops = []
+# class to contain the test_dependencies specific to this test case
+class TestAcl
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
 
-  if operating_system == 'ios_xr'
-    # unprops << TBD: XR Support
+    if operating_system == 'ios_xr'
+      # unprops << TBD: XR Support
 
-  else
-    unprops << :fragments if platform[/n(5|6)k/]
+    else
+      unprops << :fragments if platform[/n(5|6)k/]
+    end
+
+    unprops
   end
-
-  unprops
 end
 
 #################################################################
@@ -99,21 +101,21 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # ------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. ACL Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAcl)
   tests[id][:title_pattern] = 'ipv6 beaker6'
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAcl)
 
   id = :non_default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAcl)
   tests[id][:title_pattern] = 'ipv6 beaker6'
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAcl)
 
   resource_absent_cleanup(agent, 'cisco_acl')
   # ------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Title Pattern Testing")
-  test_harness_run(tests, :title_patterns_1)
-  test_harness_run(tests, :title_patterns_2)
-  test_harness_run(tests, :title_patterns_3)
+  test_harness_run(tests, :title_patterns_1, harness_class: TestAcl)
+  test_harness_run(tests, :title_patterns_2, harness_class: TestAcl)
+  test_harness_run(tests, :title_patterns_3, harness_class: TestAcl)
 
   # ---------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -116,45 +116,45 @@ tests[:non_default] = {
   },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if platform[/n(3|9)k/]
-    unprops <<
-      :fabricpath_interval <<
-      :fabricpath_slow_timer <<
-      :fabricpath_vlan
-
-  elsif platform[/n(5|6)k/]
-    unprops <<
-      :echo_rx_interval <<
-      :ipv4_echo_rx_interval <<
-      :ipv4_interval <<
-      :ipv4_slow_timer <<
-      :ipv6_echo_rx_interval <<
-      :ipv6_interval <<
-      :ipv6_slow_timer <<
-      :startup_timer
-
-  elsif platform[/n7k/]
-    unprops <<
-      :startup_timer
-  end
-  unprops
-end
-
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:interval] = '7.0.3.I6.1' if platform[/n9k$/]
-  unprops[:interval] = '7.0.3.F2.1' if platform[/n9k-f/]
-  unprops
-end
-
-# class to contain the test_harness_dependencies
+# class to contain the test_dependencies specific to this test case
 class TestBfdGlobal
   def self.test_harness_dependencies(_tests, id)
     return unless id[/non_default/]
     cmd = 'interface loopback 10'
     command_config(agent, cmd, cmd)
+  end
+
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if platform[/n(3|9)k/]
+      unprops <<
+        :fabricpath_interval <<
+        :fabricpath_slow_timer <<
+        :fabricpath_vlan
+
+    elsif platform[/n(5|6)k/]
+      unprops <<
+        :echo_rx_interval <<
+        :ipv4_echo_rx_interval <<
+        :ipv4_interval <<
+        :ipv4_slow_timer <<
+        :ipv6_echo_rx_interval <<
+        :ipv6_interval <<
+        :ipv6_slow_timer <<
+        :startup_timer
+
+    elsif platform[/n7k/]
+      unprops <<
+        :startup_timer
+    end
+    unprops
+  end
+
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:interval] = '7.0.3.I6.1' if platform[/n9k$/]
+    unprops[:interval] = '7.0.3.F2.1' if platform[/n9k-f/]
+    unprops
   end
 end
 

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -149,11 +149,13 @@ def version_unsupported_properties(_tests, _id)
   unprops
 end
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(_tests, id)
-  return unless id[/non_default/]
-  cmd = 'interface loopback 10'
-  command_config(agent, cmd, cmd)
+# class to contain the test_harness_dependencies
+class TestBfdGlobal
+  def self.test_harness_dependencies(_tests, id)
+    return unless id[/non_default/]
+    cmd = 'interface loopback 10'
+    command_config(agent, cmd, cmd)
+  end
 end
 
 def cleanup(agent)
@@ -169,10 +171,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBfdGlobal)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestBfdGlobal)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -193,67 +193,69 @@ def unsupp_prop_xr(tests, id)
   unprops
 end
 
-# Overridden to properly handle unsupported properties for this test file.
-def unsupported_properties(tests, id)
-  unprops = []
+# class to contain the test_dependencies specific to this test case
+class TestBgp
+  def self.unsupported_properties(tests, id)
+    unprops = []
 
-  vrf = vrf(tests[id])
+    vrf = vrf(tests[id])
 
-  if operating_system == 'ios_xr'
-    unprops << unsupp_prop_xr(tests, id)
-  else
-    # NX-OS does not support these properties
-    unprops << :nsr
+    if operating_system == 'ios_xr'
+      unprops << unsupp_prop_xr(tests, id)
+    else
+      # NX-OS does not support these properties
+      unprops << :nsr
 
-    unprops <<
-      :event_history_errors <<
-      :event_history_objstore if platform[/n5|n6/]
-
-    if vrf != 'default'
-      # NX-OS does not support these properties under a non-default vrf
       unprops <<
-        :disable_policy_batching <<
-        :enforce_first_as <<
-        :event_history_cli <<
-        :event_history_detail <<
         :event_history_errors <<
-        :event_history_events <<
-        :event_history_objstore <<
-        :event_history_periodic <<
-        :fast_external_fallover <<
-        :flush_routes <<
-        :neighbor_down_fib_accelerate <<
-        :suppress_fib_pending
-    end
+        :event_history_objstore if platform[/n5|n6/]
 
-    if platform[/n(5|6)k/]
-      unprops <<
-        :disable_policy_batching_ipv4 <<
-        :disable_policy_batching_ipv6 <<
-        :neighbor_down_fib_accelerate <<
-        :reconnect_interval
-    end
-  end
-  unprops
-end
+      if vrf != 'default'
+        # NX-OS does not support these properties under a non-default vrf
+        unprops <<
+          :disable_policy_batching <<
+          :enforce_first_as <<
+          :event_history_cli <<
+          :event_history_detail <<
+          :event_history_errors <<
+          :event_history_events <<
+          :event_history_objstore <<
+          :event_history_periodic <<
+          :fast_external_fallover <<
+          :flush_routes <<
+          :neighbor_down_fib_accelerate <<
+          :suppress_fib_pending
+      end
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  if platform[/n7k/]
-    unprops[:disable_policy_batching_ipv4] = '8.1.1'
-    unprops[:disable_policy_batching_ipv6] = '8.1.1'
-    unprops[:neighbor_down_fib_accelerate] = '8.1.1'
-    unprops[:reconnect_interval] = '8.1.1'
-    unprops[:event_history_errors] = '8.0'
-    unprops[:event_history_objstore] = '8.0'
-  elsif platform[/n3k$|n9k$/]
-    unprops[:event_history_errors] = '7.0.3.I5.1'
-    unprops[:event_history_objstore] = '7.0.3.I5.1'
-  elsif platform[/n(3|9)k-f/]
-    unprops[:event_history_errors] = '7.0.3.F3.2'
-    unprops[:event_history_objstore] = '7.0.3.F3.2'
+      if platform[/n(5|6)k/]
+        unprops <<
+          :disable_policy_batching_ipv4 <<
+          :disable_policy_batching_ipv6 <<
+          :neighbor_down_fib_accelerate <<
+          :reconnect_interval
+      end
+    end
+    unprops
   end
-  unprops
+
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    if platform[/n7k/]
+      unprops[:disable_policy_batching_ipv4] = '8.1.1'
+      unprops[:disable_policy_batching_ipv6] = '8.1.1'
+      unprops[:neighbor_down_fib_accelerate] = '8.1.1'
+      unprops[:reconnect_interval] = '8.1.1'
+      unprops[:event_history_errors] = '8.0'
+      unprops[:event_history_objstore] = '8.0'
+    elsif platform[/n3k$|n9k$/]
+      unprops[:event_history_errors] = '7.0.3.I5.1'
+      unprops[:event_history_objstore] = '7.0.3.I5.1'
+    elsif platform[/n(3|9)k-f/]
+      unprops[:event_history_errors] = '7.0.3.F3.2'
+      unprops[:event_history_objstore] = '7.0.3.F3.2'
+    end
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -276,11 +278,11 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -----------------------------------
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestBgp)
 
   # test removal of bgp instance
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestBgp)
 
   # now test the defaults under a non-default vrf
   cleanup(agent)
@@ -292,14 +294,14 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
   id = :non_default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestBgp)
   tests[id][:desc] = '2.1.a. Default Properties (vrf blue)'
   test_harness_bgp_vrf(tests, id, 'blue')
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
   cleanup(agent)
-  test_harness_run(tests, :title_patterns_1)
-  test_harness_run(tests, :title_patterns_2)
+  test_harness_run(tests, :title_patterns_1, harness_class: TestBgp)
+  test_harness_run(tests, :title_patterns_2, harness_class: TestBgp)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
+++ b/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
@@ -140,33 +140,35 @@ tests[:title_patterns_3] = {
   resource:      { 'ensure' => 'present' },
 }
 
-# Overridden to properly handle unsupported properties for this test file.
-def unsupported_properties(_tests, _id)
-  unprops = []
+# class to contain the test_dependencies specific to this test case
+class TestBgpNeighbor
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
 
-  if operating_system == 'ios_xr'
-    # IOS-XR does not support these properties
-    unprops <<
-      :bfd <<
-      :capability_negotiation <<
-      :dynamic_capability <<
-      :log_neighbor_changes <<
-      :low_memory_exempt <<
-      :maximum_peers <<
-      :remove_private_as
+    if operating_system == 'ios_xr'
+      # IOS-XR does not support these properties
+      unprops <<
+        :bfd <<
+        :capability_negotiation <<
+        :dynamic_capability <<
+        :log_neighbor_changes <<
+        :low_memory_exempt <<
+        :maximum_peers <<
+        :remove_private_as
 
-  else
-    unprops << :log_neighbor_changes if platform[/n(5|6)/]
-    unprops << :peer_type unless platform[/ex/]
+    else
+      unprops << :log_neighbor_changes if platform[/n(5|6)/]
+      unprops << :peer_type unless platform[/ex/]
+    end
+
+    unprops
   end
 
-  unprops
-end
-
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:log_neighbor_changes] = '8.1.1' if platform[/n7k/]
-  unprops
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:log_neighbor_changes] = '8.1.1' if platform[/n7k/]
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -186,11 +188,11 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBgpNeighbor)
 
   # test removal of bgp neighbor instance
   tests[:default][:ensure] = :absent
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBgpNeighbor)
 
   # now test the defaults under a non-default vrf
   tests[:default][:desc] = '1.1.a. Default Properties (vrf blue)'
@@ -200,20 +202,20 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestBgpNeighbor)
   tests[:non_default][:desc] = '2.1.a. Non Default Properties (vrf blue)'
   test_harness_bgp_vrf(tests, :non_default, 'blue')
   test_harness_bgp_vrf(tests, :non_default_peer_type, 'blue')
 
-  test_harness_run(tests, :non_def_local_remote_as)
+  test_harness_run(tests, :non_def_local_remote_as, harness_class: TestBgpNeighbor)
   test_harness_bgp_vrf(tests, :non_def_local_remote_as, 'blue')
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
   cleanup(agent)
-  test_harness_run(tests, :title_patterns_1)
-  test_harness_run(tests, :title_patterns_2)
-  test_harness_run(tests, :title_patterns_3)
+  test_harness_run(tests, :title_patterns_1, harness_class: TestBgpNeighbor)
+  test_harness_run(tests, :title_patterns_2, harness_class: TestBgpNeighbor)
+  test_harness_run(tests, :title_patterns_3, harness_class: TestBgpNeighbor)
 
   # -----------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_bgp_neighbor_af/test_bgpneighboraf.rb
+++ b/tests/beaker_tests/cisco_bgp_neighbor_af/test_bgpneighboraf.rb
@@ -30,26 +30,28 @@ tests = {
   resource_name: 'cisco_bgp_neighbor_af',
 }
 
-# Overridden to properly handle unsupported properties.
-def unsupported_properties(_, _)
-  unsupported_list = []
-  unsupported_list << :rewrite_evpn_rt_asn unless platform[/ex/]
-  return unsupported_list if operating_system == 'nexus'
+# class to contain the test_dependencies specific to this test case
+class TestBgpNeighborAf
+  def self.unsupported_properties(_, _)
+    unsupported_list = []
+    unsupported_list << :rewrite_evpn_rt_asn unless platform[/ex/]
+    return unsupported_list if operating_system == 'nexus'
 
-  [
-    :additional_paths_receive,
-    :additional_paths_send,
-    :default_originate_route_map,
-    :disable_peer_as_check,
-    :filter_list_in,
-    :filter_list_out,
-    :next_hop_third_party,
-    :prefix_list_in,
-    :prefix_list_out,
-    :suppress_inactive,
-    :unsuppress_map,
-    :rewrite_evpn_rt_asn,
-  ]
+    [
+      :additional_paths_receive,
+      :additional_paths_send,
+      :default_originate_route_map,
+      :disable_peer_as_check,
+      :filter_list_in,
+      :filter_list_out,
+      :next_hop_third_party,
+      :prefix_list_in,
+      :prefix_list_out,
+      :suppress_inactive,
+      :unsuppress_map,
+      :rewrite_evpn_rt_asn,
+    ]
+  end
 end
 
 # Overridden to properly handle dependencies for this test file.
@@ -340,10 +342,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBgpNeighborAf)
 
   tests[:default][:ensure] = :absent
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBgpNeighborAf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
@@ -367,11 +369,11 @@ test_name "TestCase :: #{tests[:resource_name]}" do
     :non_def_misc_maps_3,
   ].each do |id|
     tests[id][:title_pattern] = title
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestBgpNeighborAf)
   end
 
-  test_harness_run(tests, :non_def_ebgp_only)
-  test_harness_run(tests, :non_def_ibgp_only)
+  test_harness_run(tests, :non_def_ebgp_only, harness_class: TestBgpNeighborAf)
+  test_harness_run(tests, :non_def_ibgp_only, harness_class: TestBgpNeighborAf)
 
   # -------------------------------------------------------------------
   unless platform[/n3k$/]
@@ -390,19 +392,19 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
     array.each do |id|
       tests[id][:title_pattern] = title
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestBgpNeighborAf)
     end
 
     id = :non_def_ibgp_only
     tests[id][:title_pattern].gsub!(/ipv4 unicast/, 'l2vpn evpn')
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestBgpNeighborAf)
   end
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
-  test_harness_run(tests, :title_patterns_1)
-  test_harness_run(tests, :title_patterns_2)
-  test_harness_run(tests, :title_patterns_3)
-  test_harness_run(tests, :title_patterns_4)
+  test_harness_run(tests, :title_patterns_1, harness_class: TestBgpNeighborAf)
+  test_harness_run(tests, :title_patterns_2, harness_class: TestBgpNeighborAf)
+  test_harness_run(tests, :title_patterns_3, harness_class: TestBgpNeighborAf)
+  test_harness_run(tests, :title_patterns_4, harness_class: TestBgpNeighborAf)
 
   # -----------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
+++ b/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
@@ -118,38 +118,41 @@ manifest = {
 
 tests[:non_default][:manifest_props].merge!(manifest[:n56k]) if platform[/n(5|6)k/]
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if platform[/n3k$/]
-    unprops <<
-      :ipv4_src_addr_hsrp
-  elsif platform[/n(5|6)k/]
-    unprops <<
-      :ipv4_information_option_trust <<
-      :ipv4_information_trust_all <<
-      :ipv4_sub_option_circuit_id_string <<
-      :ipv6_option_cisco
-  elsif platform[/n7k/]
-    unprops <<
-      :ipv4_sub_option_circuit_id_custom <<
-      :ipv4_sub_option_circuit_id_string
-  elsif platform[/n(3|9)k-f/]
-    unprops <<
-      :ipv4_src_addr_hsrp <<
-      :ipv4_sub_option_circuit_id_custom <<
-      :ipv4_sub_option_circuit_id_string
-  elsif platform[/n9k/]
-    unprops <<
-      :ipv4_src_addr_hsrp
+# class to contain the test_dependencies specific to this test case
+class TestDhcpRelayGlobal
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if platform[/n3k$/]
+      unprops <<
+        :ipv4_src_addr_hsrp
+    elsif platform[/n(5|6)k/]
+      unprops <<
+        :ipv4_information_option_trust <<
+        :ipv4_information_trust_all <<
+        :ipv4_sub_option_circuit_id_string <<
+        :ipv6_option_cisco
+    elsif platform[/n7k/]
+      unprops <<
+        :ipv4_sub_option_circuit_id_custom <<
+        :ipv4_sub_option_circuit_id_string
+    elsif platform[/n(3|9)k-f/]
+      unprops <<
+        :ipv4_src_addr_hsrp <<
+        :ipv4_sub_option_circuit_id_custom <<
+        :ipv4_sub_option_circuit_id_string
+    elsif platform[/n9k/]
+      unprops <<
+        :ipv4_src_addr_hsrp
+    end
+    unprops << :ipv4_sub_option_circuit_id_custom if nexus_image['I2']
+    unprops
   end
-  unprops << :ipv4_sub_option_circuit_id_custom if nexus_image['I2']
-  unprops
-end
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if platform[/n9k$/]
-  unprops
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if platform[/n9k$/]
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -165,13 +168,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestDhcpRelayGlobal)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
   cleanup(agent)
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestDhcpRelayGlobal)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
+++ b/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
@@ -69,11 +69,13 @@ tests[:non_default] = {
   },
 }
 
-# The harness will remove any "unprops" from the manifests.
-def unsupported_properties(*)
-  unprops = []
-  unprops << :route_target_both if nexus_image['I2']
-  unprops
+# class to contain the test_dependencies specific to this test case
+class TestEvpnVni
+  def self.unsupported_properties(*)
+    unprops = []
+    unprops << :route_target_both if nexus_image['I2']
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -90,13 +92,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -----------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestEvpnVni)
 
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestEvpnVni)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestEvpnVni)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_hsrp/test_hsrp_global.rb
+++ b/tests/beaker_tests/cisco_hsrp/test_hsrp_global.rb
@@ -59,10 +59,13 @@ tests[:non_default] = {
   },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  unprops << :bfd_all_intf if platform[/n3k$/]
-  unprops
+# class to contain the test_dependencies specific to this test case
+class TestHsrpGlobal
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    unprops << :bfd_all_intf if platform[/n3k$/]
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -78,13 +81,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestHsrpGlobal)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
   cleanup(agent)
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestHsrpGlobal)
   # -------------------------------------------------------------------
 end
 

--- a/tests/beaker_tests/cisco_hsrp/test_interface_hsrp_group.rb
+++ b/tests/beaker_tests/cisco_hsrp/test_interface_hsrp_group.rb
@@ -184,17 +184,19 @@ def cleanup(agent)
   test_set(agent, cmd)
 end
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(_tests, _id)
-  cleanup(agent)
+# class to contain the test_harness_dependencies
+class TestInterfaceHsrpGroup
+  def self.test_harness_dependencies(_tests, _id)
+    cleanup(agent)
 
-  cmd = [
-    'feature hsrp',
-    'interface port-channel100 ; no switchport ; hsrp version 2',
-    'interface port-channel200 ; no switchport ; hsrp version 2',
-    'interface port-channel200 ; ipv6 address 2000::01/64',
-  ].join(' ; ')
-  test_set(agent, cmd)
+    cmd = [
+      'feature hsrp',
+      'interface port-channel100 ; no switchport ; hsrp version 2',
+      'interface port-channel200 ; no switchport ; hsrp version 2',
+      'interface port-channel200 ; ipv6 address 2000::01/64',
+    ].join(' ; ')
+    test_set(agent, cmd)
+  end
 end
 
 #################################################################
@@ -207,24 +209,24 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default_v4)
-  test_harness_run(tests, :default_v6)
+  test_harness_run(tests, :default_v4, harness_class: TestInterfaceHsrpGroup)
+  test_harness_run(tests, :default_v6, harness_class: TestInterfaceHsrpGroup)
 
   id = :default_v4
   tests[id][:desc] = '1.3 IPv4 Defaults (absent)'
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestInterfaceHsrpGroup)
 
   id = :default_v6
   tests[id][:desc] = '1.4 IPv6 Defaults (absent)'
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestInterfaceHsrpGroup)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default_v4)
-  test_harness_run(tests, :non_default_v6)
+  test_harness_run(tests, :non_default_v4, harness_class: TestInterfaceHsrpGroup)
+  test_harness_run(tests, :non_default_v6, harness_class: TestInterfaceHsrpGroup)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_interface/interfacelib.rb
+++ b/tests/beaker_tests/cisco_interface/interfacelib.rb
@@ -17,29 +17,30 @@
 ###############################################################################
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
-# This method overrides the method in utilitylib.rb to set up dependencies
-# for interface tests.
-def test_harness_dependencies(tests, id)
-  logger.info('  * Process test_harness_dependencies (interfacelib)')
+# class to contain the test_harness_dependencies
+class Interfacelib
+  def self.test_harness_dependencies(tests, id)
+    logger.info('  * Process test_harness_dependencies (interfacelib)')
 
-  # System-level switchport dependencies
-  if operating_system == 'nexus'
-    config_system_default_switchport?(tests, id)
-    config_system_default_switchport_shutdown?(tests, id)
-  end
+    # System-level switchport dependencies
+    if operating_system == 'nexus'
+      config_system_default_switchport?(tests, id)
+      config_system_default_switchport_shutdown?(tests, id)
+    end
 
-  # Misc dependencies
-  config_acl?(tests, id)
-  config_anycast_gateway_mac?(tests, id)
-  config_bridge_domain?(tests, id)
+    # Misc dependencies
+    config_acl?(tests, id)
+    config_anycast_gateway_mac?(tests, id)
+    config_bridge_domain?(tests, id)
 
-  # Various Cleanups
-  return unless tests[id][:preclean_intf]
-  intf = tests[id][:title_pattern]
-  if intf[/ethernet/i]
-    interface_cleanup(agent, intf)
-  else
-    remove_interface(agent, intf)
+    # Various Cleanups
+    return unless tests[id][:preclean_intf]
+    intf = tests[id][:title_pattern]
+    if intf[/ethernet/i]
+      interface_cleanup(agent, intf)
+    else
+      remove_interface(agent, intf)
+    end
   end
 end
 

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -150,12 +150,15 @@ tests[:purge] = {
   },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  unprops <<
-    :storm_control_broadcast <<
-    :storm_control_multicast if platform == 'n7k'
-  unprops
+# class to contain the test_dependencies specific to this test case
+class TestInterfaceL2
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    unprops <<
+      :storm_control_broadcast <<
+      :storm_control_multicast if platform == 'n7k'
+    unprops
+  end
 end
 
 #################################################################
@@ -169,18 +172,18 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. 'access' Property Testing")
-  test_harness_run(tests, :default_access)
+  test_harness_run(tests, :default_access, harness_class: TestInterfaceL2)
   test_harness_run(tests, :non_default_access)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. 'trunk' Property Testing")
-  test_harness_run(tests, :default_trunk)
-  test_harness_run(tests, :non_default_trunk)
+  test_harness_run(tests, :default_trunk, harness_class: TestInterfaceL2)
+  test_harness_run(tests, :non_default_trunk, harness_class: TestInterfaceL2)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2.3 Purge_config Testing")
   skip_idempotence_check = true
-  test_harness_run(tests, :purge, skip_idempotence_check)
+  test_harness_run(tests, :purge, harness_class: TestInterfaceL2, skip_idempotence_check: skip_idempotence_check)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface/test_interface_bdi.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_bdi.rb
@@ -81,11 +81,11 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: Interfacelib)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: Interfacelib)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
@@ -160,17 +160,19 @@ tests[:svi_mapping] = {
   },
 }
 
-# This method overrides utilitylib.rb:unsupported_properties()
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if platform[/n3k$/]
-    unprops <<
-      :switchport_pvlan_mapping_trunk <<
-      :switchport_pvlan_trunk_association <<
-      :switchport_pvlan_trunk_promiscuous <<
-      :switchport_pvlan_trunk_secondary
+# class to contain the test_dependencies specific to this test case
+class TestInterfacePrivateVlan
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if platform[/n3k$/]
+      unprops <<
+        :switchport_pvlan_mapping_trunk <<
+        :switchport_pvlan_trunk_association <<
+        :switchport_pvlan_trunk_promiscuous <<
+        :switchport_pvlan_trunk_secondary
+    end
+    unprops
   end
-  unprops
 end
 
 def vtp_cleanup(agent)
@@ -208,22 +210,22 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Defaults")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestInterfacePrivateVlan)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Port Mode")
-  test_harness_run(tests, :host)
-  test_harness_run(tests, :promiscuous)
+  test_harness_run(tests, :host, harness_class: TestInterfacePrivateVlan)
+  test_harness_run(tests, :promiscuous, harness_class: TestInterfacePrivateVlan)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Trunk Mode")
-  test_harness_run(tests, :trunk_secondary)
+  test_harness_run(tests, :trunk_secondary, harness_class: TestInterfacePrivateVlan)
   pvlan_assoc_cleanup(agent, intf)
-  test_harness_run(tests, :trunk_promiscuous)
+  test_harness_run(tests, :trunk_promiscuous, harness_class: TestInterfacePrivateVlan)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 4. SVI Mapping")
-  test_harness_run(tests, :svi_mapping)
+  test_harness_run(tests, :svi_mapping, harness_class: TestInterfacePrivateVlan)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_interface_evpn_multisite/test_interface_evpn_multisite.rb
+++ b/tests/beaker_tests/cisco_interface_evpn_multisite/test_interface_evpn_multisite.rb
@@ -61,9 +61,12 @@ tests[:non_default] = {
   code:           [0, 2],
 }
 
-def test_harness_dependencies(_tests, id)
-  return unless id == :default
-  test_set(agent, 'evpn multisite border 150')
+# class to contain the test_harness_dependencies
+class TestInterfaceEvpnMultisite
+  def self.test_harness_dependencies(_tests, id)
+    return unless id == :default
+    test_set(agent, 'evpn multisite border 150')
+  end
 end
 
 def cleanup(agent, intf)
@@ -82,10 +85,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestInterfaceEvpnMultisite)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestInterfaceEvpnMultisite)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
@@ -106,12 +106,15 @@ tests[:non_default] = {
   },
 }
 
-def test_harness_dependencies(tests, id)
-  return unless id == :default
-  test_set(agent, 'feature ospf ; router ospf Sample')
-  # System-level switchport dependencies
-  config_system_default_switchport?(tests, id)
-  config_system_default_switchport_shutdown?(tests, id)
+# class to contain the test_harness_dependencies
+class TestInterfaceOspf
+  def self.test_harness_dependencies(tests, id)
+    return unless id == :default
+    test_set(agent, 'feature ospf ; router ospf Sample')
+    # System-level switchport dependencies
+    config_system_default_switchport?(tests, id)
+    config_system_default_switchport_shutdown?(tests, id)
+  end
 end
 
 def cleanup(agent, intf)
@@ -128,14 +131,14 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestInterfaceOspf)
 
   id = :default
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestInterfaceOspf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestInterfaceOspf)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
+++ b/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
@@ -130,10 +130,12 @@ tests[:non_default_udp] = {
   },
 }
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(_tests, _id)
-  cmd = 'feature itd ; itd device-group icmpGroup ; itd device-group dnsGroup ; itd device-group tcpGroup ; itd device-group udpGroup'
-  command_config(agent, cmd, cmd)
+# class to contain the test_harness_dependencies
+class TestItdDeviceGroupNode
+  def self.test_harness_dependencies(_tests, _id)
+    cmd = 'feature itd ; itd device-group icmpGroup ; itd device-group dnsGroup ; itd device-group tcpGroup ; itd device-group udpGroup'
+    command_config(agent, cmd, cmd)
+  end
 end
 
 #################################################################
@@ -150,20 +152,20 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestItdDeviceGroupNode)
 
   id = :default
   tests[id][:ensure] = :absent
   tests[id].delete(:preclean)
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestItdDeviceGroupNode)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default_icmp)
-  test_harness_run(tests, :non_default_dns)
-  test_harness_run(tests, :non_default_tcp)
-  test_harness_run(tests, :non_default_udp)
+  test_harness_run(tests, :non_default_icmp, harness_class: TestItdDeviceGroupNode)
+  test_harness_run(tests, :non_default_dns, harness_class: TestItdDeviceGroupNode)
+  test_harness_run(tests, :non_default_tcp, harness_class: TestItdDeviceGroupNode)
+  test_harness_run(tests, :non_default_udp, harness_class: TestItdDeviceGroupNode)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -219,20 +219,22 @@ def cleanup(agent)
   interface_cleanup(agent, @ingress_eth_int)
 end
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(_tests, _id)
-  cleanup(agent)
+# class to contain the test_harness_dependencies
+class TestItdService
+  def self.test_harness_dependencies(_tests, _id)
+    cleanup(agent)
 
-  cmd = [
-    'feature itd',
-    'feature interface-vlan',
-    'ip access-list iap ; ip access-list eap',
-    "interface #{@ingress_eth_int} ; no switchport",
-    'vlan 2 ; interface vlan 2',
-    'interface port-channel 100 ; no switchport',
-    'itd device-group udpGroup ; node ip 1.1.1.1',
-  ].join(' ; ')
-  test_set(agent, cmd)
+    cmd = [
+      'feature itd',
+      'feature interface-vlan',
+      'ip access-list iap ; ip access-list eap',
+      "interface #{@ingress_eth_int} ; no switchport",
+      'vlan 2 ; interface vlan 2',
+      'interface port-channel 100 ; no switchport',
+      'itd device-group udpGroup ; node ip 1.1.1.1',
+    ].join(' ; ')
+    test_set(agent, cmd)
+  end
 end
 
 #################################################################
@@ -245,25 +247,25 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default)
-  test_harness_run(tests, :default_plat_1)
-  test_harness_run(tests, :default_plat_2)
+  test_harness_run(tests, :default, harness_class: TestItdService)
+  test_harness_run(tests, :default_plat_1, harness_class: TestItdService)
+  test_harness_run(tests, :default_plat_2, harness_class: TestItdService)
 
   id = :default
   tests[id][:desc] = '1.4 Common Defaults (absent)'
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestItdService)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default)
-  test_harness_run(tests, :non_default_plat_1)
-  test_harness_run(tests, :non_default_plat_2)
-  test_harness_run(tests, :non_default_shut)
-  test_harness_run(tests, :non_default_shut_2)
-  test_harness_run(tests, :non_default_shut_3)
-  test_harness_run(tests, :non_default_shut_4)
+  test_harness_run(tests, :non_default, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_plat_1, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_plat_2, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_shut, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_shut_2, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_shut_3, harness_class: TestItdService)
+  test_harness_run(tests, :non_default_shut_4, harness_class: TestItdService)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
+++ b/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
@@ -73,24 +73,27 @@ tests[:non_default] = {
   },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if platform[/n3k$/]
-    unprops <<
-      :anycast_gateway_mac <<
-      :dup_host_ip_addr_detection_host_moves <<
-      :dup_host_ip_addr_detection_timeout
+# class to contain the test_dependencies specific to this test case
+class TestOverlayGlobal
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if platform[/n3k$/]
+      unprops <<
+        :anycast_gateway_mac <<
+        :dup_host_ip_addr_detection_host_moves <<
+        :dup_host_ip_addr_detection_timeout
+    end
+    unprops
   end
-  unprops
-end
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  if platform[/n3k$/]
-    unprops[:dup_host_mac_detection_host_moves] = '7.0.3.I6.1'
-    unprops[:dup_host_mac_detection_timeout] = '7.0.3.I6.1'
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    if platform[/n3k$/]
+      unprops[:dup_host_mac_detection_host_moves] = '7.0.3.I6.1'
+      unprops[:dup_host_mac_detection_timeout] = '7.0.3.I6.1'
+    end
+    unprops
   end
-  unprops
 end
 
 def cleanup(agent)
@@ -109,7 +112,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   vdc_limit_f3_no_intf_needed(:set)
 
   # -------------------------------------------------------------------
-  test_harness_run(tests, :default)
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :default, harness_class: TestOverlayGlobal)
+  test_harness_run(tests, :non_default, harness_class: TestOverlayGlobal)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -116,50 +116,53 @@ tests[:non_default][:manifest_props].merge!(manifest_non[:n56k]) if platform[/n(
 tests[:non_default][:manifest_props].merge!(manifest_non[:n9kf]) if platform[/n(3|9)k-f/]
 tests[:non_default][:manifest_props].merge!(manifest_non[:n9k]) if platform[/n9k$/]
 
-def unsupported_properties(tests, _id)
-  unprops = []
-  if platform[/n7k/]
-    unprops <<
-      :concatenation <<
-      :hash_poly <<
-      :resilient <<
-      :symmetry
-  elsif platform[/n(5|6)k/]
-    unprops <<
-      :asymmetric <<
-      :concatenation <<
-      :hash_distribution <<
-      :load_defer <<
-      :resilient <<
-      :rotate <<
-      :symmetry
-  elsif platform[/n(3|9)k-f/]
-    unprops <<
-      :asymmetric <<
-      :concatenation <<
-      :hash_distribution <<
-      :hash_poly <<
-      :load_defer <<
-      :resilient <<
-      :symmetry
-  elsif platform[/n3k/]
-    unprops <<
-      :asymmetric <<
-      :concatenation <<
-      :hash_distribution <<
-      :hash_poly <<
-      :load_defer <<
-      :rotate
-  elsif platform[/n9k/]
-    unprops <<
-      :asymmetric <<
-      :hash_distribution <<
-      :hash_poly <<
-      :load_defer
+# class to contain the test_dependencies specific to this test case
+class TestPortChannelGlobal
+  def self.unsupported_properties(tests, _id)
+    unprops = []
+    if platform[/n7k/]
+      unprops <<
+        :concatenation <<
+        :hash_poly <<
+        :resilient <<
+        :symmetry
+    elsif platform[/n(5|6)k/]
+      unprops <<
+        :asymmetric <<
+        :concatenation <<
+        :hash_distribution <<
+        :load_defer <<
+        :resilient <<
+        :rotate <<
+        :symmetry
+    elsif platform[/n(3|9)k-f/]
+      unprops <<
+        :asymmetric <<
+        :concatenation <<
+        :hash_distribution <<
+        :hash_poly <<
+        :load_defer <<
+        :resilient <<
+        :symmetry
+    elsif platform[/n3k/]
+      unprops <<
+        :asymmetric <<
+        :concatenation <<
+        :hash_distribution <<
+        :hash_poly <<
+        :load_defer <<
+        :rotate
+    elsif platform[/n9k/]
+      unprops <<
+        :asymmetric <<
+        :hash_distribution <<
+        :hash_poly <<
+        :load_defer
+    end
+    unprops << :resilient << :symmetry if
+      tests[:resilient_unsupported]
+    unprops
   end
-  unprops << :resilient << :symmetry if
-    tests[:resilient_unsupported]
-  unprops
 end
 
 if platform[/n3k$/]
@@ -176,54 +179,54 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   device = platform
   teardown do
-    test_manifest(tests, :default)
+    test_manifest(tests, :default, harness_class: TestPortChannelGlobal)
   end
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestPortChannelGlobal)
 
   # no absent test for portchannel_global
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   id = :non_default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
   mhash = tests[id][:manifest_props]
   rhash = tests[id][:resource]
   if device == 'n7k'
     tests[id][:desc] = '2.2 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-l4port-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.3 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.4 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'l4port'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.5 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
   elsif device == 'n5k' || device == 'n6k'
     tests[id][:desc] = '2.2 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'port'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src'
     mhash[:hash_poly] = rhash[:hash_poly] = 'CRC10a' if device == 'n6k'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.3 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'port-only'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src-dst'
     mhash[:hash_poly] = rhash[:hash_poly] = 'CRC10d'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.4 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-only'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
   elsif device == 'n9k'
     tests[id][:desc] = '2.2 Non Defaults'
@@ -233,119 +236,119 @@ test_name "TestCase :: #{tests[:resource_name]}" do
     mhash[:symmetry] = rhash[:symmetry] = 'false'
     mhash[:concatenation] = rhash[:concatenation] = 'false'
     mhash[:resilient] = rhash[:resilient] = 'false'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.3 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-vlan'
     mhash[:bundle_select] = rhash[:bundle_select] = 'dst'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.4 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'l4port'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src-dst'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.5 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.6 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-gre'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
   elsif device == 'n9k-f'
     tests[id][:desc] = '2.2 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-l4port-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.3 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.4 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'l4port'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.5 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
   elsif device == 'n3k-f'
     tests[id][:desc] = '2.2 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-l4port-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.3 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-vlan'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.4 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'l4port'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
     tests[id][:desc] = '2.5 Non Defaults'
     mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
     mhash[:bundle_select] = rhash[:bundle_select] = 'src'
-    test_harness_run(tests, id)
+    test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
   elsif device == 'n3k'
     if tests[:resilient_unsupported]
       tests[id][:desc] = '2.2 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-gre'
       mhash[:bundle_select] = rhash[:bundle_select] = 'src'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.3 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
       mhash[:bundle_select] = rhash[:bundle_select] = 'dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.4 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'port'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.5 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'port-only'
       mhash[:bundle_select] = rhash[:bundle_select] = 'src-dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.6 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-gre'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.7 Non Defaults'
       mhash[:bundle_select] = rhash[:bundle_select] = 'dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
     else
       tests[id][:desc] = '2.2 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-gre'
       mhash[:bundle_select] = rhash[:bundle_select] = 'src'
       mhash[:resilient] = rhash[:resilient] = 'true'
       mhash[:symmetry] = rhash[:symmetry] = 'false'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.3 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'mac'
       mhash[:bundle_select] = rhash[:bundle_select] = 'dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.4 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'port'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.5 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'port-only'
       mhash[:bundle_select] = rhash[:bundle_select] = 'src-dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.6 Non Defaults'
       mhash[:bundle_hash] = rhash[:bundle_hash] = 'ip-gre'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
 
       tests[id][:desc] = '2.7 Non Defaults'
       mhash[:bundle_select] = rhash[:bundle_select] = 'dst'
-      test_harness_run(tests, id)
+      test_harness_run(tests, id, harness_class: TestPortChannelGlobal)
     end
   end
 

--- a/tests/beaker_tests/cisco_route_map/test_route_map.rb
+++ b/tests/beaker_tests/cisco_route_map/test_route_map.rb
@@ -526,42 +526,45 @@ def unsupp_n9kf
   unprops
 end
 
-def unsupported_properties(_tests, _id)
-  if platform[/n3k$/]
-    unsupp_n3k
-  elsif platform[/n(5|6)k/]
-    unsupp_n56k
-  elsif platform[/n7k/]
-    unsupp_n7k
-  elsif platform[/n9k$|n9k-ex/]
-    unsupp_n9k
-  elsif platform[/n(3|9)k-f/]
-    unsupp_n9kf
+# class to contain the test_dependencies specific to this test case
+class TestRouteMap
+  def self.unsupported_properties(_tests, _id)
+    if platform[/n3k$/]
+      unsupp_n3k
+    elsif platform[/n(5|6)k/]
+      unsupp_n56k
+    elsif platform[/n7k/]
+      unsupp_n7k
+    elsif platform[/n9k$|n9k-ex/]
+      unsupp_n9k
+    elsif platform[/n(3|9)k-f/]
+      unsupp_n9kf
+    end
   end
-end
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  if platform[/n(3|9)k-f/]
-    unprops[:match_metric] = '7.0.3.F2.1'
-    unprops[:set_extcommunity_4bytes_additive] = '7.0.3.F2.1'
-    unprops[:set_extcommunity_4bytes_non_transitive] = '7.0.3.F2.1'
-    unprops[:set_extcommunity_4bytes_transitive] = '7.0.3.F2.1'
-    unprops[:set_ipv4_next_hop_load_share] = '7.0.3.F2.1'
-    unprops[:set_ipv6_next_hop_load_share] = '7.0.3.F2.1'
-  elsif platform[/n9k/]
-    unprops[:match_ospf_area] = '7.0.3.I5.1'
-    unprops[:set_ipv4_next_hop_load_share] = '7.0.3.I5.1'
-    unprops[:set_ipv6_next_hop_load_share] = '7.0.3.I5.1'
-    unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
-    unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'
-    unprops[:set_community] = '7.0.3.I5.1'
-  elsif platform[/n3k/]
-    unprops[:match_ospf_area] = '7.0.3.I5.1'
-    unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
-    unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    if platform[/n(3|9)k-f/]
+      unprops[:match_metric] = '7.0.3.F2.1'
+      unprops[:set_extcommunity_4bytes_additive] = '7.0.3.F2.1'
+      unprops[:set_extcommunity_4bytes_non_transitive] = '7.0.3.F2.1'
+      unprops[:set_extcommunity_4bytes_transitive] = '7.0.3.F2.1'
+      unprops[:set_ipv4_next_hop_load_share] = '7.0.3.F2.1'
+      unprops[:set_ipv6_next_hop_load_share] = '7.0.3.F2.1'
+    elsif platform[/n9k/]
+      unprops[:match_ospf_area] = '7.0.3.I5.1'
+      unprops[:set_ipv4_next_hop_load_share] = '7.0.3.I5.1'
+      unprops[:set_ipv6_next_hop_load_share] = '7.0.3.I5.1'
+      unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
+      unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'
+      unprops[:set_community] = '7.0.3.I5.1'
+    elsif platform[/n3k/]
+      unprops[:match_ospf_area] = '7.0.3.I5.1'
+      unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
+      unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'
+    end
+    unprops
   end
-  unprops
 end
 
 def cleanup(agent)
@@ -577,21 +580,21 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestRouteMap)
 
   id = :default
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestRouteMap)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default_1)
-  test_harness_run(tests, :non_default_2)
-  test_harness_run(tests, :non_default_3)
-  test_harness_run(tests, :non_default_4)
-  test_harness_run(tests, :non_default_5)
-  test_harness_run(tests, :non_default_6)
+  test_harness_run(tests, :non_default_1, harness_class: TestRouteMap)
+  test_harness_run(tests, :non_default_2, harness_class: TestRouteMap)
+  test_harness_run(tests, :non_default_3, harness_class: TestRouteMap)
+  test_harness_run(tests, :non_default_4, harness_class: TestRouteMap)
+  test_harness_run(tests, :non_default_5, harness_class: TestRouteMap)
+  test_harness_run(tests, :non_default_6, harness_class: TestRouteMap)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_snmp_server/test_snmp_server.rb
+++ b/tests/beaker_tests/cisco_snmp_server/test_snmp_server.rb
@@ -89,10 +89,13 @@ def cleanup(agent)
   test_set(agent, cmds)
 end
 
-def unsupported_properties(*)
-  unprops = []
-  unprops << :packet_size if image?[/7.0.3.I2|I3/] # CSCuz14217
-  unprops
+# class to contain the test_dependencies specific to this test case
+class TestSnmpServer
+  def self.unsupported_properties(*)
+    unprops = []
+    unprops << :packet_size if image?[/7.0.3.I2|I3/] # CSCuz14217
+    unprops
+  end
 end
 
 #################################################################
@@ -104,10 +107,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestSnmpServer)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestSnmpServer)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -208,7 +208,7 @@ tests[:non_default_bd] = {
   },
 }
 
-# class to contain the test_harness_dependencies
+# class to contain the harness_dependencies specific to these tests
 class TestStpGlobal
   def self.test_harness_dependencies(_tests, id)
     return unless platform == 'n7k'
@@ -220,20 +220,20 @@ class TestStpGlobal
       command_config(agent, cmd, cmd)
     end
   end
-end
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  unprops << :domain if platform[/n(3|9)k-f/]
-  unprops << :fcoe if platform[/n(3|5|6|7)k/]
-  unprops
-end
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    unprops << :domain if platform[/n(3|9)k-f/]
+    unprops << :fcoe if platform[/n(3|5|6|7)k/]
+    unprops
+  end
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:domain] = '7.0.3.I6.1' if platform[/n3k$/]
-  unprops[:domain] = '7.0.3.I6.1' if platform[/n9k$/]
-  unprops
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:domain] = '7.0.3.I6.1' if platform[/n3k$/]
+    unprops[:domain] = '7.0.3.I6.1' if platform[/n9k$/]
+    unprops
+  end
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -208,15 +208,17 @@ tests[:non_default_bd] = {
   },
 }
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(_tests, id)
-  return unless platform == 'n7k'
-  if id == :default_bd || id == :non_default_bd
-    cmd = 'system bridge-domain all'
-    command_config(agent, cmd, cmd)
-  else
-    cmd = 'system bridge-domain all ; system bridge-domain none'
-    command_config(agent, cmd, cmd)
+# class to contain the test_harness_dependencies
+class TestStpGlobal
+  def self.test_harness_dependencies(_tests, id)
+    return unless platform == 'n7k'
+    if id == :default_bd || id == :non_default_bd
+      cmd = 'system bridge-domain all'
+      command_config(agent, cmd, cmd)
+    else
+      cmd = 'system bridge-domain all ; system bridge-domain none'
+      command_config(agent, cmd, cmd)
+    end
   end
 end
 
@@ -243,15 +245,15 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default)
-  test_harness_run(tests, :default_bd)
-  test_harness_run(tests, :default_mst)
+  test_harness_run(tests, :default, harness_class: TestStpGlobal)
+  test_harness_run(tests, :default_bd, harness_class: TestStpGlobal)
+  test_harness_run(tests, :default_mst, harness_class: TestStpGlobal)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default)
-  test_harness_run(tests, :non_default_bd)
+  test_harness_run(tests, :non_default, harness_class: TestStpGlobal)
+  test_harness_run(tests, :non_default_bd, harness_class: TestStpGlobal)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -46,11 +46,14 @@ tests[:non_default] = {
   manifest_props: { limit_resource_module_type: 'f3' },
 }
 
-def test_harness_dependencies(_tests, id)
-  return unless id == :non_default
+# class to contain the test_harness_dependencies
+class TestVdc
+  def self.test_harness_dependencies(_tests, id)
+    return unless id == :non_default
 
-  # Set module-type to default value
-  limit_resource_module_type_set(default_vdc_name, nil)
+    # Set module-type to default value
+    limit_resource_module_type_set(default_vdc_name, nil)
+  end
 end
 
 #################################################################
@@ -61,6 +64,6 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestVdc)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_vlan/test_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_vlan.rb
@@ -109,15 +109,18 @@ if platform[/n3k$/]
                    'Hardware is not capable of supporting vn-segment-vlan-based feature')
 end
 
-def unsupported_properties(tests, _id)
-  unprops = []
+# class to contain the test_dependencies specific to this test case
+class TestVlan
+  def self.unsupported_properties(tests, _id)
+    unprops = []
 
-  unprops << :mapped_vni if platform[/n7k/] || tests[:vn_segment_unsupported]
+    unprops << :mapped_vni if platform[/n7k/] || tests[:vn_segment_unsupported]
 
-  unprops << :fabric_control unless platform[/n7k/]
+    unprops << :fabric_control unless platform[/n7k/]
 
-  logger.info("  unprops: #{unprops}") unless unprops.empty?
-  unprops
+    logger.info("  unprops: #{unprops}") unless unprops.empty?
+    unprops
+  end
 end
 
 #################################################################
@@ -132,13 +135,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   remove_all_vlans(agent)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Property Testing")
-  test_harness_run(tests, :default_standard)
-  test_harness_run(tests, :non_default_standard)
+  test_harness_run(tests, :default_standard, harness_class: TestVlan)
+  test_harness_run(tests, :non_default_standard, harness_class: TestVlan)
 
   # Cleanup between standard and extended vlan tests.
   remove_all_vlans(agent)
-  test_harness_run(tests, :default_extended)
-  test_harness_run(tests, :non_default_extended)
+  test_harness_run(tests, :default_extended, harness_class: TestVlan)
+  test_harness_run(tests, :non_default_extended, harness_class: TestVlan)
 end
 
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
+++ b/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
@@ -173,11 +173,14 @@ tests[:vpc_plus_non_default_properties_n7k] = {
   },
 }
 
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:layer3_peer_routing] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
-  unprops[:shutdown] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
-  unprops
+# class to contain the test_dependencies specific to this test case
+class TestVpcDomain
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:layer3_peer_routing] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
+    unprops[:shutdown] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
+    unprops
+  end
 end
 
 def cleanup(agent)
@@ -198,33 +201,33 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
 
-  test_harness_run(tests, :default_properties)
-  test_harness_run(tests, :default_properties_n7k)
+  test_harness_run(tests, :default_properties, harness_class: TestVpcDomain)
+  test_harness_run(tests, :default_properties_n7k, harness_class: TestVpcDomain)
 
   # Resource absent test
   tests[:default_properties][:ensure] = :absent
-  test_harness_run(tests, :default_properties)
+  test_harness_run(tests, :default_properties, harness_class: TestVpcDomain)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default_properties)
-  test_harness_run(tests, :non_default_properties_n6k7k)
-  test_harness_run(tests, :non_default_properties_n7k)
+  test_harness_run(tests, :non_default_properties, harness_class: TestVpcDomain)
+  test_harness_run(tests, :non_default_properties_n6k7k, harness_class: TestVpcDomain)
+  test_harness_run(tests, :non_default_properties_n7k, harness_class: TestVpcDomain)
 
   # Resource absent test
   tests[:non_default_properties][:ensure] = :absent
-  test_harness_run(tests, :non_default_properties)
+  test_harness_run(tests, :non_default_properties, harness_class: TestVpcDomain)
 
   # ------------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. vPC+ Non Default Property Testing")
   # Need to setup fabricapth env for vPC+
   # setup_fabricpath_env(tests, self)
   vdc_limit_f3_no_intf_needed(:set)
-  test_harness_run(tests, :vpc_plus_non_default_properties_n7k)
+  test_harness_run(tests, :vpc_plus_non_default_properties_n7k, harness_class: TestVpcDomain)
 
   # Resource absent test
   tests[:vpc_plus_non_default_properties_n7k][:ensure] = :absent
-  test_harness_run(tests, :vpc_plus_non_default_properties_n7k)
+  test_harness_run(tests, :vpc_plus_non_default_properties_n7k, harness_class: TestVpcDomain)
 
   skipped_tests_summary(tests)
 end

--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -64,27 +64,30 @@ tests[:non_default] = {
   },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if operating_system == 'nexus'
-    unprops <<
-      :mhost_ipv4_default_interface <<
-      :mhost_ipv6_default_interface <<
-      :remote_route_filtering <<
-      :vpn_id
+# class to contain the test_dependencies specific to this test case
+class TestVrf
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if operating_system == 'nexus'
+      unprops <<
+        :mhost_ipv4_default_interface <<
+        :mhost_ipv6_default_interface <<
+        :remote_route_filtering <<
+        :vpn_id
 
-    unprops << :vni unless platform[/n9k/]
-    unprops << :route_distinguisher if nexus_image['I2']
-    unprops << :description if image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
+      unprops << :vni unless platform[/n9k/]
+      unprops << :route_distinguisher if nexus_image['I2']
+      unprops << :description if image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
 
-  else
-    unprops <<
-      :route_distinguisher <<
-      :shutdown <<
-      :vni
+    else
+      unprops <<
+        :route_distinguisher <<
+        :shutdown <<
+        :vni
+    end
+    logger.info("  unprops: #{unprops}") unless unprops.empty?
+    unprops
   end
-  logger.info("  unprops: #{unprops}") unless unprops.empty?
-  unprops
 end
 
 # Overridden to properly handle dependencies for this test file.
@@ -109,14 +112,14 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVrf)
 
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVrf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_run(tests, :non_default)
-  skipped_tests_summary(tests)
+  skipped_tests_summary(tests, harness_class: TestVrf)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
+++ b/tests/beaker_tests/cisco_vrf_af/test_vrf_af.rb
@@ -102,44 +102,47 @@ tests[:title_patterns_3] = {
   resource:      { 'ensure' => 'present' },
 }
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if operating_system == 'nexus'
-    unprops <<
-      :route_target_export_stitching <<
-      :route_target_import_stitching
-
-    if platform[/n3k$/]
+# class to contain the test_dependencies specific to this test case
+class TestVrfAf
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if operating_system == 'nexus'
       unprops <<
-        :route_target_both_auto <<
-        :route_target_both_auto_evpn <<
-        :route_target_export_evpn <<
-        :route_target_import_evpn
-    end
+        :route_target_export_stitching <<
+        :route_target_import_stitching
 
-    if platform[/n9k(-ex)?$/]
-      if image?[/I[2-6]/]
+      if platform[/n3k$/]
+        unprops <<
+          :route_target_both_auto <<
+          :route_target_both_auto_evpn <<
+          :route_target_export_evpn <<
+          :route_target_import_evpn
+      end
+
+      if platform[/n9k(-ex)?$/]
+        if image?[/I[2-6]/]
+          unprops <<
+            :route_target_both_auto_mvpn <<
+            :route_target_export_mvpn <<
+            :route_target_import_mvpn
+        end
+      else
         unprops <<
           :route_target_both_auto_mvpn <<
           :route_target_export_mvpn <<
           :route_target_import_mvpn
       end
+
     else
       unprops <<
-        :route_target_both_auto_mvpn <<
-        :route_target_export_mvpn <<
-        :route_target_import_mvpn
+        :route_target_both_auto <<
+        :route_target_both_auto_evpn <<
+        :route_target_export_evpn <<
+        :route_target_import_evpn
+
     end
-
-  else
-    unprops <<
-      :route_target_both_auto <<
-      :route_target_both_auto_evpn <<
-      :route_target_export_evpn <<
-      :route_target_import_evpn
-
+    unprops
   end
-  unprops
 end
 
 # Overridden to properly handle dependencies for this test file.
@@ -178,22 +181,22 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVrfAf)
 
   tests[id][:ensure] = :absent
   tests[id].delete(:preclean)
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVrfAf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestVrfAf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")
   remove_all_vrfs(agent)
-  test_harness_run(tests, :title_patterns_1)
-  test_harness_run(tests, :title_patterns_2)
-  test_harness_run(tests, :title_patterns_3)
+  test_harness_run(tests, :title_patterns_1, harness_class: TestVrfAf)
+  test_harness_run(tests, :title_patterns_2, harness_class: TestVrfAf)
+  test_harness_run(tests, :title_patterns_3, harness_class: TestVrfAf)
 
   # -----------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -64,19 +64,6 @@ tests[:non_default] = {
   },
 }
 
-def unsupported_properties(*)
-  unprops = []
-  unprops << :source_interface_hold_down_time if platform[/n(5|6)k/]
-  unprops << :multisite_border_gateway_interface unless platform[/ex/]
-  unprops
-end
-
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:source_interface_hold_down_time] = '8.1.1' if platform[/n7k/]
-  unprops
-end
-
 # class to contain the test_harness_dependencies
 class TestVxlanVtep
   def self.test_harness_dependencies(*)
@@ -87,6 +74,19 @@ class TestVxlanVtep
     # Vxlan has a hard requirement to disable feature fabricpath on n5/6k
     cmd = 'no feature-set fabricpath'
     command_config(agent, cmd, cmd)
+  end
+
+  def self.unsupported_properties(*)
+    unprops = []
+    unprops << :source_interface_hold_down_time if platform[/n(5|6)k/]
+    unprops << :multisite_border_gateway_interface unless platform[/ex/]
+    unprops
+  end
+
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:source_interface_hold_down_time] = '8.1.1' if platform[/n7k/]
+    unprops
   end
 end
 

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -77,15 +77,17 @@ def version_unsupported_properties(_tests, _id)
   unprops
 end
 
-# Overridden to properly handle dependencies for this test file.
-def test_harness_dependencies(*)
-  test_set(agent, 'evpn multisite border 150') if platform[/ex/]
-  return unless platform[/n(5|6)k/]
-  skip_if_nv_overlay_rejected(agent)
+# class to contain the test_harness_dependencies
+class TestVxlanVtep
+  def self.test_harness_dependencies(*)
+    test_set(agent, 'evpn multisite border 150') if platform[/ex/]
+    return unless platform[/n(5|6)k/]
+    skip_if_nv_overlay_rejected(agent)
 
-  # Vxlan has a hard requirement to disable feature fabricpath on n5/6k
-  cmd = 'no feature-set fabricpath'
-  command_config(agent, cmd, cmd)
+    # Vxlan has a hard requirement to disable feature fabricpath on n5/6k
+    cmd = 'no feature-set fabricpath'
+    command_config(agent, cmd, cmd)
+  end
 end
 
 #################################################################
@@ -104,13 +106,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -----------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxlanVtep)
 
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxlanVtep)
 
   # -----------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :non_default, harness_class: TestVxlanVtep)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -256,20 +256,26 @@ class TestVxLanVtepVni
     return unless platform[/n(5|6)k/]
     skip_if_nv_overlay_rejected(agent)
   end
-end
 
-def unsupported_properties(_tests, _id)
-  unprops = []
-  if platform[/n(5|6|7)k/]
-    unprops <<
-      :ingress_replication <<
-      :peer_list
-  elsif platform[/n(3k-f|9k)/]
-    unprops <<
-      :suppress_uuc
+  def self.unsupported_properties(_tests, _id)
+    unprops = []
+    if platform[/n(5|6|7)k/]
+      unprops <<
+        :ingress_replication <<
+        :peer_list
+    elsif platform[/n(3k-f|9k)/]
+      unprops <<
+        :suppress_uuc
+    end
+    unprops << :multisite_ingress_replication unless platform[/ex/]
+    unprops
   end
-  unprops << :multisite_ingress_replication unless platform[/ex/]
-  unprops
+
+  def self.version_unsupported_properties(_tests, _id)
+    unprops = {}
+    unprops[:suppress_uuc] = '8.1.1' if platform[/n7k/]
+    unprops
+  end
 end
 
 # Overridden to properly handle dependencies for this test file.
@@ -290,12 +296,6 @@ def dependency_manifest(_tests, _id)
       }
     "
   end
-end
-
-def version_unsupported_properties(_tests, _id)
-  unprops = {}
-  unprops[:suppress_uuc] = '8.1.1' if platform[/n7k/]
-  unprops
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -249,10 +249,13 @@ tests[:multisite_ingress_replication_false] = {
 # It will be changed to a property in future. A correspoding test
 # will be added here.
 
-def test_harness_dependencies(*)
-  test_set(agent, 'evpn multisite border 150') if platform[/ex/]
-  return unless platform[/n(5|6)k/]
-  skip_if_nv_overlay_rejected(agent)
+# class to contain the test_harness_dependencies
+class TestVxLanVtepVni
+  def self.test_harness_dependencies(*)
+    test_set(agent, 'evpn multisite border 150') if platform[/ex/]
+    return unless platform[/n(5|6)k/]
+    skip_if_nv_overlay_rejected(agent)
+  end
 end
 
 def unsupported_properties(_tests, _id)
@@ -311,23 +314,23 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default_properties_ingress_replication
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxLanVtepVni)
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxLanVtepVni)
   id = :default_properties_multicast_group
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxLanVtepVni)
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestVxLanVtepVni)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :ingress_replication_static_peer_list_empty)
-  test_harness_run(tests, :peer_list)
-  test_harness_run(tests, :peer_list_change_add)
-  test_harness_run(tests, :peer_list_default)
-  test_harness_run(tests, :ingress_replication_bgp)
-  test_harness_run(tests, :multicast_group)
+  test_harness_run(tests, :ingress_replication_static_peer_list_empty, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :peer_list, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :peer_list_change_add, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :peer_list_default, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :ingress_replication_bgp, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :multicast_group, harness_class: TestVxLanVtepVni)
 
   # TBD - The suppress_arp tests will generate the following error.
   #  ERROR: Please configure TCAM region... Configuring the TCAM region
@@ -337,10 +340,10 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # test_harness_run(tests, :suppress_arp_true)
   # test_harness_run(tests, :suppress_arp_false)
 
-  test_harness_run(tests, :suppress_uuc_true)
-  test_harness_run(tests, :suppress_uuc_false)
-  test_harness_run(tests, :multisite_ingress_replication_true)
-  test_harness_run(tests, :multisite_ingress_replication_false)
+  test_harness_run(tests, :suppress_uuc_true, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :suppress_uuc_false, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :multisite_ingress_replication_true, harness_class: TestVxLanVtepVni)
+  test_harness_run(tests, :multisite_ingress_replication_false, harness_class: TestVxLanVtepVni)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -800,15 +800,6 @@ def create_package_manifest_resource(tests, id)
   true
 end
 
-# test_harness_dependencies
-#
-# This method is used for additional testbed setup beyond the basics
-# used by most tests.
-# Override this in a particular test file as needed.
-def test_harness_dependencies(tests, id)
-  # default is to do nothing
-end
-
 # dependency_manifest
 #
 # This method returns a string representation of a manifest that contains
@@ -884,7 +875,7 @@ end
 # - Creates manifests
 # - Creates puppet resource title strings
 # - Cleans resource
-def test_harness_run(tests, id, skip_idempotence_check=false)
+def test_harness_run(tests, id, harness_class: nil, skip_idempotence_check: false)
   return unless platform_supports_test(tests, id)
   logger.info("\n  * Process test_harness_run")
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
@@ -900,7 +891,7 @@ def test_harness_run(tests, id, skip_idempotence_check=false)
     tests[id][:preclean]
 
   # Check for additional pre-requisites
-  test_harness_dependencies(tests, id)
+  harness_class.test_harness_dependencies(tests, id) if harness_class
 
   test_harness_common(tests, id, skip_idempotence_check)
   tests[id][:ensure] = nil

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -242,7 +242,7 @@ end
 # Reserved keys
 # tests[id][:log_desc] - the final form of the log description
 #
-def test_harness_common(tests, id, skip_idempotence_check=false)
+def test_harness_common(tests, id, harness_class: nil, skip_idempotence_check: false)
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
   tests[id][:state] = false if tests[id][:state].nil?
   tests[id][:desc] = '' if tests[id][:desc].nil?
@@ -250,7 +250,7 @@ def test_harness_common(tests, id, skip_idempotence_check=false)
   logger.info("\n--------\n#{tests[id][:log_desc]}")
 
   test_manifest(tests, id)
-  test_resource(tests, id)
+  test_resource(tests, id, harness_class: harness_class)
   test_idempotence(tests, id) unless skip_idempotence_check
   remove_temp_manifest
   tests[id].delete(:log_desc)
@@ -311,21 +311,21 @@ def test_manifest(tests, id)
 end
 
 # Wrapper for 'puppet resource' command tests
-def test_resource(tests, id, state=false)
+def test_resource(tests, id, harness_class: nil, state: false)
   stepinfo = format_stepinfo(tests, id, 'RESOURCE')
   step "TestStep :: #{stepinfo}" do
     logger.debug("test_resource :: cmd:\n#{tests[id][:resource_cmd]}")
     if tests[:agent]
       on(tests[:agent], tests[id][:resource_cmd]) do
         search_pattern_in_output(
-          stdout, supported_property_hash(tests, id, tests[id][:resource]),
+          stdout, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
           state, self, logger
         )
       end
     else
       output = `#{tests[id][:resource_cmd]}`
       search_pattern_in_output(
-        output, supported_property_hash(tests, id, tests[id][:resource]),
+        output, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
         state, self, logger
       )
     end
@@ -715,7 +715,7 @@ end
 #   parameter keys in the manifest. When these are used the puppet resource
 #   command string becomes a combination of the title pattern and these params.
 #
-def create_manifest_and_resource(tests, id)
+def create_manifest_and_resource(tests, id, harness_class: nil)
   fail 'tests[:resource_name] is not defined' unless tests[:resource_name]
 
   tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
@@ -740,7 +740,7 @@ def create_manifest_and_resource(tests, id)
 
     manifest_props = tests[id][:manifest_props]
     if manifest_props
-      manifest_props = supported_property_hash(tests, id, manifest_props)
+      manifest_props = supported_property_hash(tests, id, manifest_props, harness_class: harness_class)
 
       # we shouldn't continue if all properties were removed
       return false if
@@ -809,45 +809,21 @@ def dependency_manifest(_tests, _id)
   nil # indicates no manifest dependencies
 end
 
-# unsupported_properties
-#
-# Returns an array of properties that are not supported for
-# a particular operating_system or platform.
-# Override this in a particular test file as needed.
-def unsupported_properties(_tests, _id)
-  [] # defaults to no unsupported properties
-end
-
-# version_unsupported_properties
-#
-# Returns an array of properties that are not supported for
-# a particular operating_system or platform for a particular
-# software version.
-# Override this in a particular test file as needed.
-# Ex: If property 'ipv4_sub_option_circuit_id_string' is
-# supported on n9k only on version '7.0.3.I6.1' or higher
-# then add this line in the overridden method.
-# unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if
-#   platform[/n9k$/]
-def version_unsupported_properties(_tests, _id)
-  {} # defaults to no version_unsupported properties
-end
-
 # supported_property_hash
 #
 # This method creates a clone of the specified property
 # hash containing only the key/values of properties
 # that are supported for the specified test (based on
 # operating_system, platform, etc.).
-def supported_property_hash(tests, id, property_hash)
+def supported_property_hash(tests, id, property_hash, harness_class: nil)
   return nil if property_hash.nil?
   copy = property_hash.clone
-  unsupported_properties(tests, id).each do |prop_symbol|
+  harness_class.unsupported_properties(tests, id).each do |prop_symbol|
     copy.delete(prop_symbol)
     # because :resource hash currently uses strings for keys
     copy.delete(prop_symbol.to_s)
-  end
-  return copy if version_unsupported_properties(tests, id).empty?
+  end if harness_class && harness_class.respond_to?(:unsupported_properties)
+  return copy unless harness_class && harness_class.respond_to?(:version_unsupported_properties)
   lim = full_version.split[0].tr('(', '.').tr(')', '.').chomp('.')
   # due to a bug in Gem::Version, we need to append a letter
   # to the version field if the to be compared version
@@ -858,14 +834,14 @@ def supported_property_hash(tests, id, property_hash)
   # 7.0.3.I2.2e < 7.0.3.I2.2a is FALSE
   append_a = false
   append_a = true if lim[-1, 1] =~ /[[:alpha:]]/
-  version_unsupported_properties(tests, id).each do |key, val|
+  harness_class.version_unsupported_properties(tests, id).each do |key, val|
     val << 'a' if append_a
     append_a = false
     next unless Gem::Version.new(lim) < Gem::Version.new(val)
     copy.delete(key)
     # because :resource hash currently uses strings for keys
     copy.delete(key.to_s)
-  end
+  end if harness_class.respond_to?(:version_unsupported_properties)
   copy
 end
 
@@ -881,7 +857,7 @@ def test_harness_run(tests, id, harness_class: nil, skip_idempotence_check: fals
   tests[id][:ensure] = :present if tests[id][:ensure].nil?
 
   # Build the manifest for this test
-  unless create_manifest_and_resource(tests, id)
+  unless create_manifest_and_resource(tests, id, harness_class: harness_class)
     logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
     logger.error('No supported properties remain for this test.')
     return
@@ -891,9 +867,9 @@ def test_harness_run(tests, id, harness_class: nil, skip_idempotence_check: fals
     tests[id][:preclean]
 
   # Check for additional pre-requisites
-  harness_class.test_harness_dependencies(tests, id) if harness_class
+  harness_class.test_harness_dependencies(tests, id) if harness_class && harness_class.respond_to?(:test_harness_dependencies)
 
-  test_harness_common(tests, id, skip_idempotence_check)
+  test_harness_common(tests, id, harness_class: harness_class, skip_idempotence_check: skip_idempotence_check)
   tests[id][:ensure] = nil
 end
 


### PR DESCRIPTION
Previously `test_harness_dependencies` would get called from an existing class without having relevancy to the current test, which causes unexpected behaviour.

By passing it where required, it should also increase the test performance as it is no longer performing the `test_harness_dependencies` from interface lib on every test case.