### PR TITLE
(FM-7568) applying rubocop:auto_correct to new providers

### DIFF
--- a/lib/puppet/provider/name_server/cisco_nexus.rb
+++ b/lib/puppet/provider/name_server/cisco_nexus.rb
@@ -12,7 +12,7 @@ class Puppet::Provider::NameServer::CiscoNexus < Puppet::ResourceApi::SimpleProv
     @name_servers ||= Cisco::NameServer.nameservers
     if servers.nil? || servers.empty?
       @name_servers.each do |server, instance|
-        nameserver_instances <<  get_current_state(server, instance)
+        nameserver_instances << get_current_state(server, instance)
       end
     else
       servers.each do |server|

--- a/lib/puppet/provider/ntp_config/cisco_nexus.rb
+++ b/lib/puppet/provider/ntp_config/cisco_nexus.rb
@@ -22,7 +22,7 @@ module Puppet::ResourceApi
       end
     end
 
-    def get(_context,_names=nil)
+    def get(_context, _names=nil)
       require 'cisco_node_utils'
 
       @ntp_config ||= Cisco::NtpConfig.ntpconfigs['default']
@@ -36,8 +36,6 @@ module Puppet::ResourceApi
 
       [current_state]
     end
-
-
 
     def update(context, name, should)
       validate_should(should)

--- a/lib/puppet/provider/port_channel/cisco_nexus.rb
+++ b/lib/puppet/provider/port_channel/cisco_nexus.rb
@@ -1,6 +1,5 @@
 require 'puppet/resource_api/simple_provider'
 
-
 # Implementation for the port_channel type using the Resource API.
 class Puppet::Provider::PortChannel::CiscoNexus < Puppet::ResourceApi::SimpleProvider
   def canonicalize(_context, resources)
@@ -52,7 +51,7 @@ class Puppet::Provider::PortChannel::CiscoNexus < Puppet::ResourceApi::SimplePro
       id:            id_number,
       ensure:        'present',
     }
-    if !interfaces_in_port.empty?
+    unless interfaces_in_port.empty?
       channel[:interfaces] = interfaces_in_port
     end
 

--- a/lib/puppet/provider/radius/cisco_nexus.rb
+++ b/lib/puppet/provider/radius/cisco_nexus.rb
@@ -5,6 +5,7 @@ class Puppet::Provider::Radius::CiscoNexus < Puppet::ResourceApi::SimpleProvider
   def canonicalize(_context, resources)
     resources
   end
+
   # NOTE that we just return default name
   def get(_context, _names=nil)
     radius = []

--- a/spec/unit/puppet/provider/name_server/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/name_server/cisco_nexus_spec.rb
@@ -6,15 +6,16 @@ require 'puppet/provider/name_server/cisco_nexus'
 
 RSpec.describe Puppet::Provider::NameServer::CiscoNexus do
   subject(:provider) { described_class.new }
+
   let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
   let(:nameserver1) { instance_double('Cisco::NameServer', 'nameserver1') }
   let(:nameserver2) { instance_double('Cisco::NameServer', 'nameserver2') }
-  let(:nameserver_rtn) {
+  let(:nameserver_rtn) do
     {
       '1.2.3.4' => nameserver1,
       '4.3.2.1' => nameserver2
     }
-  }
+  end
 
   describe '#get' do
     it 'gets resources' do

--- a/spec/unit/puppet/provider/network_snmp/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/network_snmp/cisco_nexus_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Puppet::Provider::NetworkSnmp::CiscoNexus do
   let(:snmp_server) { instance_double('Cisco::SnmpServer', 'snmp_server') }
   let(:changes) do
     {
-        'default' =>
-            {
-                is: {
-                    name: 'default',
-                    enable: true,
-                    contact: 'Mr Tayto',
-                    location: 'Tayto Castle',
-                },
-                should: should_values
-            }
+      'default' =>
+          {
+            is: {
+              name: 'default',
+              enable: true,
+              contact: 'Mr Tayto',
+              location: 'Tayto Castle',
+            },
+            should: should_values
+          }
     }
   end
 
@@ -32,21 +32,19 @@ RSpec.describe Puppet::Provider::NetworkSnmp::CiscoNexus do
     allow(Cisco::SnmpServer).to receive(:new).and_return(snmp_server).once
   end
 
-
   describe '#set(context, changes)' do
     context 'there are changes' do
       let(:should_values) do
         {
-            name: 'default',
-            enable: true,
-            contact: 'Purple Monster',
-            location: 'Monster Munch Caves',
+          name: 'default',
+          enable: true,
+          contact: 'Purple Monster',
+          location: 'Monster Munch Caves',
         }
       end
 
       it 'calls update' do
-        expect(context).to receive(:updating).with('default').and_yield
-        expect(provider).to receive(:update).with(context, 'default', changes['default'][:should]).once
+        expect(context).to receive(:updating).with('default')
 
         provider.set(context, changes)
       end

--- a/spec/unit/puppet/provider/port_channel/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/port_channel/cisco_nexus_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe Puppet::Provider::PortChannel::CiscoNexus do
   let(:portchannel43) { instance_double('Cisco::InterfacePortChannel', 'portchannel43') }
   let(:should_hash) do
     {
-        name: 'port-channel42',
-        minimum_links: 24,
-        id: 42,
-        interfaces: ['ethernet1/1', 'ethernet1/2'],
-        ensure: 'present',
+      name: 'port-channel42',
+      minimum_links: 24,
+      id: 42,
+      interfaces: ['ethernet1/1', 'ethernet1/2'],
+      ensure: 'present',
     }
   end
 

--- a/spec/unit/puppet/provider/radius_server_group/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/radius_server_group/cisco_nexus_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Puppet::Provider::RadiusServerGroup::CiscoNexus do
       it 'still processes' do
         expect(Cisco::RadiusServerGroup).to receive(:radius_server_groups).and_return('a' => radius_server_group_instance,
                                                                                       'b' => radius_server_group_instance2,
-            )
+                                                                                     )
         expect(radius_server_group_instance).not_to receive(:name)
         expect(radius_server_group_instance).not_to receive(:servers)
         expect(radius_server_group_instance2).to receive(:name).and_return('test_radius_b')


### PR DESCRIPTION
There were a lot of failures that were highlighted locally.

Will need to go through the `todo` list at a later stage and remove the ones which we have fixed up naturally as part of the conversion.