### PR TITLE
(maint) fixes to the test_get utillib for agentless mode

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1020,7 +1020,7 @@ def test_get(agent, filter, opt=:raw)
     env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
     Cisco::Environment.add_env('remote', env)
     test_client = Cisco::Client.create('remote')
-    command = test_client.get(data_fomat: :cli, command: filter)
+    command = test_client.get(data_fomat: :cli, command: "show running-config all | #{filter}")
   end
   case opt
   when :raw

--- a/tests/beaker_tests/radius_global/test_radius_global.rb
+++ b/tests/beaker_tests/radius_global/test_radius_global.rb
@@ -66,7 +66,7 @@ def cleanup(agent)
   test_set(agent, 'no ip radius source-interface')
 
   # To remove a configured key we have ot know the key value
-  test_get(agent, 'show running-config radius | include key')
+  test_get(agent, 'include radius | include key')
   key = stdout.match('^radius-server key (\d+)\s+(.*)') if stdout
   command_config(agent, "no radius-server key #{key[1]} #{key[2]}", "removing key #{key[2]}") if key
 end


### PR DESCRIPTION
Previously the commands would fail with the following error when running agentlessly:

```
Cisco::CliError: The command 'incl 'vrf context' | excl management' was rejected with error:
Syntax error while parsing 'incl 'vrf context' | excl management'
```

When checking the `cisco_command_config` it made use of `show running-config all` before each command.