### PR TITLE
(maint) new approach to scoping utilitylib

### DIFF
--- a/tests/beaker_tests/cisco_aaa_group_tacacs/test_aaa_group_tacacs.rb
+++ b/tests/beaker_tests/cisco_aaa_group_tacacs/test_aaa_group_tacacs.rb
@@ -61,18 +61,21 @@ tests[:non_default] = {
   },
 }
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(_tests, id)
-  dep = ''
-  if id == :non_default
-    dep = %(
-      cisco_tacacs_server      { 'default': ensure => present }
-      cisco_tacacs_server_host { 'bkrhost': ensure => present }
-      cisco_tacacs_server_host { '1.1.1.1': ensure => present }
-    )
+# class to contain the test_dependencies specific to this test case
+class TestAaaGroupTacacs < BaseHarness
+  # Overridden to properly handle dependencies for this test file.
+  def self.dependency_manifest(ctx, _tests, id)
+    dep = ''
+    if id == :non_default
+      dep = %(
+        cisco_tacacs_server      { 'default': ensure => present }
+        cisco_tacacs_server_host { 'bkrhost': ensure => present }
+        cisco_tacacs_server_host { '1.1.1.1': ensure => present }
+      )
+    end
+    ctx.logger.info("\n  * dependency_manifest\n#{dep}")
+    dep
   end
-  logger.info("\n  * dependency_manifest\n#{dep}")
-  dep
 end
 
 #################################################################
@@ -82,15 +85,15 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   id = :default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAaaGroupTacacs)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
   id = :non_default
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAaaGroupTacacs)
   tests[id][:ensure] = :absent
-  test_harness_run(tests, id)
+  test_harness_run(tests, id, harness_class: TestAaaGroupTacacs)
 
   # -------------------------------------------------------------------
   resource_absent_cleanup(agent, 'cisco_aaa_group_tacacs')

--- a/tests/beaker_tests/cisco_acl/test_ace.rb
+++ b/tests/beaker_tests/cisco_acl/test_ace.rb
@@ -137,40 +137,26 @@ tests[:seq_50_icmp_v4] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestAce
-  def self.unsupported_properties(tests, id)
-    unprops = []
-
-    if operating_system == 'ios_xr'
-      # unprops << TBD: XR Support
-
-    else
-      if tests[id][:title_pattern][/ipv6/]
-        unprops <<
-          :http_method <<
-          :precedence <<
-          :redirect <<
-          :tcp_option_length
-      end
-      if platform[/n(5|6)k/]
-        unprops <<
-          :proto_option <<
-          :packet_length <<
-          :time_range
-      end
-      if platform[/n(5|6|7)k/]
-        unprops <<
-          :http_method <<
-          :redirect <<
-          :vlan <<
-          :tcp_option_length <<
-          :set_erspan_dscp <<
-          :set_erspan_gre_proto <<
-          :ttl
-      end
+class TestAce < BaseHarness
+  def self.unsupported_properties(ctx, tests, id)
+    if tests[id][:title_pattern][/ipv6/]
+      [:http_method,
+       :precedence,
+       :redirect,
+       :tcp_option_length]
+    elsif ctx.platform[/n(5|6)k/]
+      [:proto_option,
+       :packet_length,
+       :time_range]
+    elsif ctx.platform[/n(5|6|7)k/]
+      [:http_method,
+       :redirect,
+       :vlan,
+       :tcp_option_length,
+       :set_erspan_dscp,
+       :set_erspan_gre_proto,
+       :ttl]
     end
-
-    unprops
   end
 end
 

--- a/tests/beaker_tests/cisco_acl/test_acl.rb
+++ b/tests/beaker_tests/cisco_acl/test_acl.rb
@@ -36,10 +36,10 @@ tests[:default] = {
   desc:           '1.1 Default tests',
   title_pattern:  'ipv4 beaker',
   manifest_props: {
-    fragments: 'default'
+    fragments: 'default',
   },
   resource:       {
-    'stats_per_entry' => 'false'
+    'stats_per_entry' => 'false',
   },
 }
 
@@ -76,18 +76,13 @@ tests[:title_patterns_3] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestAcl
-  def self.unsupported_properties(_tests, _id)
-    unprops = []
-
-    if operating_system == 'ios_xr'
-      # unprops << TBD: XR Support
-
+class TestAcl < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
+    if ctx.platform[%r{n(3k-f|5k|6k|9k-f)}]
+      [:fragments]
     else
-      unprops << :fragments if platform[/n(3k-f|5k|6k|9k-f)/]
+      []
     end
-
-    unprops
   end
 end
 

--- a/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
+++ b/tests/beaker_tests/cisco_bfd_global/test_bfd_global.rb
@@ -117,43 +117,36 @@ tests[:non_default] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestBfdGlobal
-  def self.test_harness_dependencies(_tests, id)
-    return unless id[/non_default/]
+class TestBfdGlobal < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, id)
+    return unless id[%r{non_default}]
     cmd = 'interface loopback 10'
-    command_config(agent, cmd, cmd)
+    ctx.command_config(ctx.agent, cmd, cmd)
   end
 
-  def self.unsupported_properties(_tests, _id)
-    unprops = []
-    if platform[/n(3|9)k/]
-      unprops <<
-        :fabricpath_interval <<
-        :fabricpath_slow_timer <<
-        :fabricpath_vlan
-
-    elsif platform[/n(5|6)k/]
-      unprops <<
-        :echo_rx_interval <<
-        :ipv4_echo_rx_interval <<
-        :ipv4_interval <<
-        :ipv4_slow_timer <<
-        :ipv6_echo_rx_interval <<
-        :ipv6_interval <<
-        :ipv6_slow_timer <<
-        :startup_timer
-
-    elsif platform[/n7k/]
-      unprops <<
-        :startup_timer
+  def self.unsupported_properties(ctx, _tests, _id)
+    if ctx.platform[/n(3|9)k/]
+      [:fabricpath_interval,
+       :fabricpath_slow_timer,
+       :fabricpath_vlan]
+    elsif ctx.platform[/n(5|6)k/]
+      [:echo_rx_interval,
+       :ipv4_echo_rx_interval,
+       :ipv4_interval,
+       :ipv4_slow_timer,
+       :ipv6_echo_rx_interval,
+       :ipv6_interval,
+       :ipv6_slow_timer,
+       :startup_timer]
+    elsif ctx.platform[/n7k/]
+      [:startup_timer]
     end
-    unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:interval] = '7.0.3.I6.1' if platform[/n9k$/]
-    unprops[:interval] = '7.0.3.F2.1' if platform[/n9k-f/]
+    unprops[:interval] = '7.0.3.I6.1' if ctx.platform[/n9k$/]
+    unprops[:interval] = '7.0.3.F2.1' if ctx.platform[/n9k-f/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_bgp/bgplib.rb
+++ b/tests/beaker_tests/cisco_bgp/bgplib.rb
@@ -16,39 +16,42 @@
 # Require UtilityLib.rb path.
 require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 
-# This helper tests a test case in vrf context. This allows for testing a vrf
-# while an existing config is present in vrf default.
-def test_harness_bgp_vrf(tests, id, vrf)
-  orig_desc = tests[id][:desc]
-  tests[id][:desc] += " (vrf #{vrf})"
+# Monkeypatch all our utility functions into beaker's TestCase, so that we don't poison the global namespace
+class Beaker::TestCase
+  # This helper tests a test case in vrf context. This allows for testing a vrf
+  # while an existing config is present in vrf default.
+  def test_harness_bgp_vrf(tests, id, vrf, harness_class: BaseHarness)
+    orig_desc = tests[id][:desc]
+    tests[id][:desc] += " (vrf #{vrf})"
 
-  orig_title_pattern = tests[id][:title_pattern]
-  words = orig_title_pattern.split
-  if words.length > 1
-    words[1] = vrf
-    tests[id][:title_pattern] = words.join(' ')
-  elsif tests[id][:manifest_props] && tests[id][:manifest_props][:vrf]
-    orig_vrf = tests[id][:manifest_props][:vrf]
-    tests[id][:manifest_props][:vrf] = vrf
+    orig_title_pattern = tests[id][:title_pattern]
+    words = orig_title_pattern.split
+    if words.length > 1
+      words[1] = vrf
+      tests[id][:title_pattern] = words.join(' ')
+    elsif tests[id][:manifest_props] && tests[id][:manifest_props][:vrf]
+      orig_vrf = tests[id][:manifest_props][:vrf]
+      tests[id][:manifest_props][:vrf] = vrf
+    end
+
+    test_harness_run(tests, id, harness_class: harness_class)
+
+    # put the original values back
+    tests[id][:desc] = orig_desc
+    tests[id][:title_pattern] = orig_title_pattern
+    tests[id][:manifest_props][:vrf] = orig_vrf
   end
 
-  test_harness_run(tests, id)
+  # Returns the vrf being tested by the specified test.
+  def vrf(test)
+    return test[:title_params][:vrf] if
+      test[:title_params] && test[:title_params][:vrf]
 
-  # put the original values back
-  tests[id][:desc] = orig_desc
-  tests[id][:title_pattern] = orig_title_pattern
-  tests[id][:manifest_props][:vrf] = orig_vrf
-end
+    if test[:title_pattern]
+      words = test[:title_pattern].split(' ')
+      return words[1] unless words.length < 2
+    end
 
-# Returns the vrf being tested by the specified test.
-def vrf(test)
-  return test[:title_params][:vrf] if
-    test[:title_params] && test[:title_params][:vrf]
-
-  if test[:title_pattern]
-    words = test[:title_pattern].split(' ')
-    return words[1] unless words.length < 2
+    'default'
   end
-
-  'default'
 end

--- a/tests/beaker_tests/cisco_bgp/test_bgp.rb
+++ b/tests/beaker_tests/cisco_bgp/test_bgp.rb
@@ -154,61 +154,22 @@ tests[:title_patterns_2] = {
   resource:      { 'ensure' => 'present' },
 }
 
-def unsupp_prop_xr(tests, id)
-  unprops = []
-  vrf = vrf(tests[id])
-
-  unprops <<
-    :bestpath_med_non_deterministic <<
-    :disable_policy_batching <<
-    :event_history_cli <<
-    :event_history_detail <<
-    :event_history_events <<
-    :event_history_errors <<
-    :event_history_objstore <<
-    :event_history_periodic <<
-    :flush_routes <<
-    :graceful_restart_helper <<
-    :isolate <<
-    :log_neighbor_changes <<
-    :maxas_limit <<
-    :neighbor_down_fib_accelerate <<
-    :shutdown <<
-    :suppress_fib_pending <<
-    :timer_bestpath_limit <<
-    :timer_bestpath_limit_always
-
-  if vrf != 'default'
-    # IOS-XR does not support these properties under a non-default vrf
-    unprops <<
-      :bestpath_med_confed <<
-      :cluster_id <<
-      :confederation_id <<
-      :confederation_peers <<
-      :graceful_restart <<
-      :graceful_restart_timers_restart <<
-      :graceful_restart_timers_stalepath_time <<
-      :nsr
-  end
-  unprops
-end
-
 # class to contain the test_dependencies specific to this test case
-class TestBgp
-  def self.unsupported_properties(tests, id)
+class TestBgp < BaseHarness
+  def self.unsupported_properties(ctx, tests, id)
     unprops = []
 
-    vrf = vrf(tests[id])
+    vrf = ctx.vrf(tests[id])
 
-    if operating_system == 'ios_xr'
-      unprops << unsupp_prop_xr(tests, id)
+    if ctx.operating_system == 'ios_xr'
+      unprops << unsupp_prop_xr(ctx, tests, id)
     else
       # NX-OS does not support these properties
       unprops << :nsr
 
       unprops <<
         :event_history_errors <<
-        :event_history_objstore if platform[/n5|n6/]
+        :event_history_objstore if ctx.platform[/n5|n6/]
 
       if vrf != 'default'
         # NX-OS does not support these properties under a non-default vrf
@@ -227,7 +188,7 @@ class TestBgp
           :suppress_fib_pending
       end
 
-      if platform[/n(5|6)k/]
+      if ctx.platform[/n(5|6)k/]
         unprops <<
           :disable_policy_batching_ipv4 <<
           :disable_policy_batching_ipv6 <<
@@ -238,21 +199,60 @@ class TestBgp
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    if platform[/n7k/]
+    if ctx.platform[/n7k/]
       unprops[:disable_policy_batching_ipv4] = '8.1.1'
       unprops[:disable_policy_batching_ipv6] = '8.1.1'
       unprops[:neighbor_down_fib_accelerate] = '8.1.1'
       unprops[:reconnect_interval] = '8.1.1'
       unprops[:event_history_errors] = '8.0'
       unprops[:event_history_objstore] = '8.0'
-    elsif platform[/n3k$|n9k$/]
+    elsif ctx.platform[/n3k$|n9k$/]
       unprops[:event_history_errors] = '7.0.3.I5.1'
       unprops[:event_history_objstore] = '7.0.3.I5.1'
-    elsif platform[/n(3|9)k-f/]
+    elsif ctx.platform[/n(3|9)k-f/]
       unprops[:event_history_errors] = '7.0.3.F3.2'
       unprops[:event_history_objstore] = '7.0.3.F3.2'
+    end
+    unprops
+  end
+
+  def self.unsupp_prop_xr(ctx, tests, id)
+    unprops = []
+    vrf = ctx.vrf(tests[id])
+
+    unprops <<
+      :bestpath_med_non_deterministic <<
+      :disable_policy_batching <<
+      :event_history_cli <<
+      :event_history_detail <<
+      :event_history_events <<
+      :event_history_errors <<
+      :event_history_objstore <<
+      :event_history_periodic <<
+      :flush_routes <<
+      :graceful_restart_helper <<
+      :isolate <<
+      :log_neighbor_changes <<
+      :maxas_limit <<
+      :neighbor_down_fib_accelerate <<
+      :shutdown <<
+      :suppress_fib_pending <<
+      :timer_bestpath_limit <<
+      :timer_bestpath_limit_always
+
+    if vrf != 'default'
+      # IOS-XR does not support these properties under a non-default vrf
+      unprops <<
+        :bestpath_med_confed <<
+        :cluster_id <<
+        :confederation_id <<
+        :confederation_peers <<
+        :graceful_restart <<
+        :graceful_restart_timers_restart <<
+        :graceful_restart_timers_stalepath_time <<
+        :nsr
     end
     unprops
   end

--- a/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
+++ b/tests/beaker_tests/cisco_bgp_af/test_bgpaf.rb
@@ -190,58 +190,13 @@ tests[:l2vpn_evpn] = {
   resource:         { 'ensure' => 'present' },
 }
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(tests, id)
-  extra_config = ''
-  if operating_system == 'ios_xr'
-    vrf = vrf(tests[id])
-
-    # XR requires the following before a vrf AF can be configured:
-    #   1. a global router_id
-    #   2. a global address family
-    #   3. route_distinguisher configured on the vrf
-    extra_config = "
-      cisco_bgp { '2 default':
-        ensure              => present,
-        router_id           => '1.2.3.4',
-      }"
-
-    parent_title = '2 default vpnv4 unicast'
-    if parent_title != tests[id][:title_pattern]
-      extra_config += "
-        cisco_bgp_af { '#{parent_title}':
-          ensure            => present,
-        }"
-    end
-
-    # Ensure any needed route-policies are present.
-    # TODO: Replace this with cisco_route_policy config,
-    # when/if that is available.
-    extra_config += "
-      cisco_command_config { 'policy_config':
-        command => '
-          route-policy RouteMap
-            end-policy'
-      }"
-
-    if vrf != 'default'
-      extra_config += "
-      cisco_bgp { '2 #{vrf}':
-        ensure              => present,
-        route_distinguisher => auto,
-      }"
-    end
-  end
-  extra_config
-end
-
 # class to contain the test_dependencies specific to this test case
-class TestBgpAf
-  def self.unsupported_properties(tests, id)
+class TestBgpAf < BaseHarness
+  def self.unsupported_properties(ctx, tests, id)
     unprops = []
 
-    vrf = vrf(tests[id])
-    if operating_system == 'ios_xr'
+    vrf = ctx.vrf(tests[id])
+    if ctx.operating_system == 'ios_xr'
       # IOS-XR does not support these properties
       unprops <<
         :additional_paths_install <<
@@ -266,20 +221,64 @@ class TestBgpAf
           :dampening_suppress_time
       end
     else
-      unprops << :advertise_l2vpn_evpn if
-        vrf == 'default' || platform[/n(3|6)k$/]
+      unprops << :advertise_l2vpn_evpn if vrf == 'default' || ctx.platform[/n(3|6)k$/]
 
-      unprops << :additional_paths_install if platform[/n(3|9)k/]
-      unprops << :additional_paths_selection if platform[/n9k$/] && nexus_image[/I5.3/]
-      unprops << :additional_paths_selection if platform[/n9k/] && nexus_image[/F2.1/]
+      unprops << :additional_paths_install if ctx.platform[/n(3|9)k/]
+      unprops << :additional_paths_selection if ctx.platform[/n9k$/] && ctx.nexus_image[/I5.3/]
+      unprops << :additional_paths_selection if ctx.platform[/n9k/] && ctx.nexus_image[/F2.1/]
     end
     unprops
+  end
+
+  # Overridden to properly handle dependencies for this test file.
+  def self.dependency_manifest(ctx, tests, id)
+    extra_config = ''
+    if ctx.operating_system == 'ios_xr'
+      vrf = ctx.vrf(tests[id])
+
+      # XR requires the following before a vrf AF can be configured:
+      #   1. a global router_id
+      #   2. a global address family
+      #   3. route_distinguisher configured on the vrf
+      extra_config = "
+        cisco_bgp { '2 default':
+          ensure              => present,
+          router_id           => '1.2.3.4',
+        }"
+
+      parent_title = '2 default vpnv4 unicast'
+      if parent_title != tests[id][:title_pattern]
+        extra_config += "
+          cisco_bgp_af { '#{parent_title}':
+            ensure            => present,
+          }"
+      end
+
+      # Ensure any needed route-policies are present.
+      # TODO: Replace this with cisco_route_policy config,
+      # when/if that is available.
+      extra_config += "
+        cisco_command_config { 'policy_config':
+          command => '
+            route-policy RouteMap
+              end-policy'
+        }"
+
+      if vrf != 'default'
+        extra_config += "
+        cisco_bgp { '2 #{vrf}':
+          ensure              => present,
+          route_distinguisher => auto,
+        }"
+      end
+    end
+    extra_config
   end
 end
 
 def test_harness_bgp_af_run(tests, id)
   test_harness_run(tests, id, harness_class: TestBgpAf) # test in default vrf
-  test_harness_bgp_vrf(tests, id, 'blue') # test in non-default vrf
+  test_harness_bgp_vrf(tests, id, 'blue', harness_class: TestBgpAf) # test in non-default vrf
 end
 
 def cleanup(agent)
@@ -309,9 +308,9 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   cleanup(agent)
-  test_harness_bgp_af_run(tests, :non_default)
-  test_harness_bgp_af_run(tests, :non_default_arrays)
-  test_harness_bgp_af_run(tests, :non_default_dampening_routemap)
+  test_harness_bgp_af_run(tests, :non_default, harness_class: TestBgpAf)
+  test_harness_bgp_af_run(tests, :non_default_arrays, harness_class: TestBgpAf)
+  test_harness_bgp_af_run(tests, :non_default_dampening_routemap, harness_class: TestBgpAf)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 3. Title Pattern Testing")

--- a/tests/beaker_tests/cisco_bgp_af_aa/test_bgp_af_aa.rb
+++ b/tests/beaker_tests/cisco_bgp_af_aa/test_bgp_af_aa.rb
@@ -70,20 +70,23 @@ tests[:non_default2] = {
   },
 }
 
-def dependency_manifest(_tests, _id)
-  "
-    cisco_bgp { '2 default':
-      ensure => present,
-    }
+# class to contain the test_dependencies specific to this test case
+class TestBgpAfAa < BaseHarness
+  def self.dependency_manifest(_ctx, _tests, _id)
+    "
+      cisco_bgp { '2 default':
+        ensure => present,
+      }
 
-    cisco_bgp_af { '2 default ipv4 unicast':
-      ensure => present,
-    }
+      cisco_bgp_af { '2 default ipv4 unicast':
+        ensure => present,
+      }
 
-    cisco_bgp_af { '2 red ipv6 multicast':
-      ensure => present,
-    }
-  "
+      cisco_bgp_af { '2 red ipv6 multicast':
+        ensure => present,
+      }
+    "
+  end
 end
 
 def cleanup(agent)
@@ -99,13 +102,13 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, harness_class: TestBgpAfAa)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
 
-  test_harness_run(tests, :non_default1)
-  test_harness_run(tests, :non_default2)
+  test_harness_run(tests, :non_default1, harness_class: TestBgpAfAa)
+  test_harness_run(tests, :non_default2, harness_class: TestBgpAfAa)
 
   # -------------------------------------------------------------------
   skipped_tests_summary(tests)

--- a/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
+++ b/tests/beaker_tests/cisco_bgp_neighbor/test_bgpneighbor.rb
@@ -141,11 +141,11 @@ tests[:title_patterns_3] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestBgpNeighbor
-  def self.unsupported_properties(_tests, _id)
+class TestBgpNeighbor < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
 
-    if operating_system == 'ios_xr'
+    if ctx.operating_system == 'ios_xr'
       # IOS-XR does not support these properties
       unprops <<
         :bfd <<
@@ -157,16 +157,16 @@ class TestBgpNeighbor
         :remove_private_as
 
     else
-      unprops << :log_neighbor_changes if platform[/n(5|6)/]
-      unprops << :peer_type unless platform[/ex/]
+      unprops << :log_neighbor_changes if ctx.platform[/n(5|6)/]
+      unprops << :peer_type unless ctx.platform[/ex/]
     end
 
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:log_neighbor_changes] = '8.1.1' if platform[/n7k/]
+    unprops[:log_neighbor_changes] = '8.1.1' if ctx.platform[/n7k/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
+++ b/tests/beaker_tests/cisco_dhcp_relay_global/test_dhcp_relay_global.rb
@@ -119,38 +119,38 @@ manifest = {
 tests[:non_default][:manifest_props].merge!(manifest[:n56k]) if platform[/n(5|6)k/]
 
 # class to contain the test_dependencies specific to this test case
-class TestDhcpRelayGlobal
-  def self.unsupported_properties(_tests, _id)
+class TestDhcpRelayGlobal < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    if platform[/n3k$/]
+    if ctx.platform[/n3k$/]
       unprops <<
         :ipv4_src_addr_hsrp
-    elsif platform[/n(5|6)k/]
+    elsif ctx.platform[/n(5|6)k/]
       unprops <<
         :ipv4_information_option_trust <<
         :ipv4_information_trust_all <<
         :ipv4_sub_option_circuit_id_string <<
         :ipv6_option_cisco
-    elsif platform[/n7k/]
+    elsif ctx.platform[/n7k/]
       unprops <<
         :ipv4_sub_option_circuit_id_custom <<
         :ipv4_sub_option_circuit_id_string
-    elsif platform[/n(3|9)k-f/]
+    elsif ctx.platform[/n(3|9)k-f/]
       unprops <<
         :ipv4_src_addr_hsrp <<
         :ipv4_sub_option_circuit_id_custom <<
         :ipv4_sub_option_circuit_id_string
-    elsif platform[/n9k/]
+    elsif ctx.platform[/n9k/]
       unprops <<
         :ipv4_src_addr_hsrp
     end
-    unprops << :ipv4_sub_option_circuit_id_custom if nexus_image['I2']
+    unprops << :ipv4_sub_option_circuit_id_custom if ctx.nexus_image['I2']
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if platform[/n9k$/]
+    unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if ctx.platform[/n9k$/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
+++ b/tests/beaker_tests/cisco_evpn_vni/test_evpn_vni.rb
@@ -70,10 +70,10 @@ tests[:non_default] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestEvpnVni
-  def self.unsupported_properties(*)
+class TestEvpnVni < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    unprops << :route_target_both if nexus_image['I2']
+    unprops << :route_target_both if ctx.nexus_image['I2']
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_hsrp/test_hsrp_global.rb
+++ b/tests/beaker_tests/cisco_hsrp/test_hsrp_global.rb
@@ -60,10 +60,10 @@ tests[:non_default] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestHsrpGlobal
-  def self.unsupported_properties(_tests, _id)
+class TestHsrpGlobal < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    unprops << :bfd_all_intf if platform[/n3k$/]
+    unprops << :bfd_all_intf if ctx.platform[/n3k$/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_hsrp/test_interface_hsrp_group.rb
+++ b/tests/beaker_tests/cisco_hsrp/test_interface_hsrp_group.rb
@@ -176,18 +176,18 @@ tests[:non_default_v6] = {
   },
 }
 
-def cleanup(agent)
-  cmd = ['no interface port-channel 100',
-         'no interface port-channel 200',
-         'no feature hsrp',
-        ].join(' ; ')
-  test_set(agent, cmd)
-end
-
 # class to contain the test_harness_dependencies
-class TestInterfaceHsrpGroup
-  def self.test_harness_dependencies(_tests, _id)
-    cleanup(agent)
+class TestInterfaceHsrpGroup < BaseHarness
+  def self.cleanup(ctx)
+    cmd = ['no interface port-channel 100',
+           'no interface port-channel 200',
+           'no feature hsrp',
+          ].join(' ; ')
+    ctx.test_set(ctx.agent, cmd)
+  end
+
+  def self.test_harness_dependencies(ctx, _tests, _id)
+    cleanup(ctx)
 
     cmd = [
       'feature hsrp',
@@ -195,8 +195,13 @@ class TestInterfaceHsrpGroup
       'interface port-channel200 ; no switchport ; hsrp version 2',
       'interface port-channel200 ; ipv6 address 2000::01/64',
     ].join(' ; ')
-    test_set(agent, cmd)
+
+    ctx.test_set(ctx.agent, cmd)
   end
+end
+
+def cleanup
+  TestInterfaceHsrpGroup.cleanup(self)
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_interface/test_interface_L2.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L2.rb
@@ -151,12 +151,12 @@ tests[:purge] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestInterfaceL2
-  def self.unsupported_properties(_tests, _id)
+class TestInterfaceL2 < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
     unprops <<
       :storm_control_broadcast <<
-      :storm_control_multicast if platform == 'n7k'
+      :storm_control_multicast if ctx.platform == 'n7k'
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_interface/test_interface_L3.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_L3.rb
@@ -160,11 +160,11 @@ tests[:ip_forwarding] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestInterfaceL3
-  def self.unsupported_properties(_tests, id)
+class TestInterfaceL3 < BaseHarness
+  def self.unsupported_properties(ctx, _tests, id)
     unprops = []
 
-    if operating_system == 'ios_xr'
+    if ctx.operating_system == 'ios_xr'
       unprops <<
         :bfd_echo <<
         :duplex <<
@@ -182,10 +182,10 @@ class TestInterfaceL3
         :switchport_mode
     end
 
-    if platform[/n(3|9)k/]
+    if ctx.platform[/n(3|9)k/]
       unprops <<
         :ipv4_dhcp_relay_src_addr_hsrp
-    elsif platform[/n(5|6)k/]
+    elsif ctx.platform[/n(5|6)k/]
       unprops <<
         :ipv4_dhcp_relay_info_trust
     end
@@ -195,17 +195,17 @@ class TestInterfaceL3
 
     unprops
   end
-end
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(_tests, id)
-  return unless id == :non_default
-  # Though not required on most platforms, the test vrf context should be
-  # instantiated prior to configuring settings on a vrf interface. The new
-  # DME-based cli's (PIM, etc) may fail otherwise.
-  dep = %( cisco_vrf { 'test1': description => 'Puppet test vrf' } )
-  logger.info("\n  * dependency_manifest\n#{dep}")
-  dep
+  # Overridden to properly handle dependencies for this test file.
+  def self.dependency_manifest(ctx, _tests, id)
+    return unless id == :non_default
+    # Though not required on most platforms, the test vrf context should be
+    # instantiated prior to configuring settings on a vrf interface. The new
+    # DME-based cli's (PIM, etc) may fail otherwise.
+    dep = %( cisco_vrf { 'test1': description => 'Puppet test vrf' } )
+    ctx.logger.info("\n  * dependency_manifest\n#{dep}")
+    dep
+  end
 end
 
 def cleanup(agent, intf, dot1q)

--- a/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_capabilities.rb
@@ -99,8 +99,7 @@ def interface_pre_check(tests, intf) # rubocop:disable Metrics/AbcSize
   dup = caps['Duplex']
   mtu = caps['MTU']
 
-  tests[:default][:manifest_props][:negotiate_auto] = 'true' unless
-    platform[/n7k/]
+  tests[:default][:manifest_props][:negotiate_auto] = 'true' unless platform[/n7k/]
   tests[:default][:manifest_props][:duplex] = 'auto' if dup.delete('auto')
   tests[:default][:manifest_props][:speed] = 'auto' if spd.delete('auto')
 
@@ -110,8 +109,7 @@ def interface_pre_check(tests, intf) # rubocop:disable Metrics/AbcSize
 
   # Cannot turn off auto-negotiate for speeds 10G+
   non_default_speed = tests[:non_default][:manifest_props][:speed]
-  tests[:non_default][:manifest_props][:negotiate_auto] = 'false' unless
-    platform[/n7k/] || non_default_speed.to_i >= 10_000
+  tests[:non_default][:manifest_props][:negotiate_auto] = 'false' unless platform[/n7k/] || non_default_speed.to_i >= 10_000
 
   logger.info("\n      Pre-Check :default hash: #{tests[:default]}"\
               "\n      Pre-Check :non_default hash: #{tests[:non_default]}")

--- a/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
+++ b/tests/beaker_tests/cisco_interface/test_interface_private_vlan.rb
@@ -161,10 +161,10 @@ tests[:svi_mapping] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestInterfacePrivateVlan
-  def self.unsupported_properties(_tests, _id)
+class TestInterfacePrivateVlan < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    if platform[/n3k$/]
+    if ctx.platform[/n3k$/]
       unprops <<
         :switchport_pvlan_mapping_trunk <<
         :switchport_pvlan_trunk_association <<
@@ -172,6 +172,10 @@ class TestInterfacePrivateVlan
         :switchport_pvlan_trunk_secondary
     end
     unprops
+  end
+
+  def self.dependency_manifest(_ctx, tests, id)
+    tests[id][:dependency] if tests[id][:dependency]
   end
 end
 
@@ -186,11 +190,6 @@ end
 def pvlan_assoc_cleanup(agent, intf)
   logger.info("\n#{'-' * 60}\nPrivate-vlan cleanup")
   resource_set(agent, ['cisco_interface', intf, 'switchport_mode', 'disabled'])
-end
-
-# This method overrides utilitylib.rb:dependency_manifest()
-def dependency_manifest(tests, id)
-  tests[id][:dependency] if tests[id][:dependency]
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_interface_evpn_multisite/test_interface_evpn_multisite.rb
+++ b/tests/beaker_tests/cisco_interface_evpn_multisite/test_interface_evpn_multisite.rb
@@ -62,10 +62,10 @@ tests[:non_default] = {
 }
 
 # class to contain the test_harness_dependencies
-class TestInterfaceEvpnMultisite
-  def self.test_harness_dependencies(_tests, id)
+class TestInterfaceEvpnMultisite < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, id)
     return unless id == :default
-    test_set(agent, 'evpn multisite border 150')
+    ctx.test_set(agent, 'evpn multisite border 150')
   end
 end
 

--- a/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
+++ b/tests/beaker_tests/cisco_interface_ospf/test_interface_ospf.rb
@@ -107,13 +107,13 @@ tests[:non_default] = {
 }
 
 # class to contain the test_harness_dependencies
-class TestInterfaceOspf
-  def self.test_harness_dependencies(tests, id)
+class TestInterfaceOspf < BaseHarness
+  def self.test_harness_dependencies(ctx, tests, id)
     return unless id == :default
-    test_set(agent, 'feature ospf ; router ospf Sample')
+    ctx.test_set(agent, 'feature ospf ; router ospf Sample')
     # System-level switchport dependencies
-    config_system_default_switchport?(tests, id)
-    config_system_default_switchport_shutdown?(tests, id)
+    ctx.config_system_default_switchport?(tests, id)
+    ctx.config_system_default_switchport_shutdown?(tests, id)
   end
 end
 

--- a/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
+++ b/tests/beaker_tests/cisco_interface_service_vni/test_interface_service_vni.rb
@@ -66,18 +66,21 @@ tests[:non_default] = {
   },
 }
 
-def dependency_manifest(tests, id)
-  return unless id == :default
-  dep = %(
-    cisco_encapsulation {'vni_500_5000':
-      dot1q_map => ['500', '5000'],
-    }
-    cisco_interface{ '#{tests[:intf]}':
-      switchport_mode => 'disabled',
-    }
-  )
-  logger.info("\n  * dependency_manifest\n#{dep}")
-  dep
+# class to contain the test_dependencies specific to this test case
+class TestInterfaceServiceVni < BaseHarness
+  def self.dependency_manifest(ctx, tests, id)
+    return unless id == :default
+    dep = %(
+      cisco_encapsulation {'vni_500_5000':
+        dot1q_map => ['500', '5000'],
+      }
+      cisco_interface{ '#{tests[:intf]}':
+        switchport_mode => 'disabled',
+      }
+    )
+    ctx.logger.info("\n  * dependency_manifest\n#{dep}")
+    dep
+  end
 end
 
 #################################################################
@@ -94,7 +97,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
-  test_harness_run(tests, :non_default)
+  test_harness_run(tests, :default, harness_class: TestInterfaceServiceVni)
+  test_harness_run(tests, :non_default, harness_class: TestInterfaceServiceVni)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
+++ b/tests/beaker_tests/cisco_itd_device_group_node/test_itd_device_group_node.rb
@@ -131,10 +131,10 @@ tests[:non_default_udp] = {
 }
 
 # class to contain the test_harness_dependencies
-class TestItdDeviceGroupNode
-  def self.test_harness_dependencies(_tests, _id)
+class TestItdDeviceGroupNode < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, _id)
     cmd = 'feature itd ; itd device-group icmpGroup ; itd device-group dnsGroup ; itd device-group tcpGroup ; itd device-group udpGroup'
-    command_config(agent, cmd, cmd)
+    ctx.command_config(ctx.agent, cmd, cmd)
   end
 end
 

--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -220,8 +220,8 @@ def cleanup(agent)
 end
 
 # class to contain the test_harness_dependencies
-class TestItdService
-  def self.test_harness_dependencies(_tests, _id)
+class TestItdService < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, _id)
     cleanup(agent)
 
     cmd = [
@@ -233,7 +233,7 @@ class TestItdService
       'interface port-channel 100 ; no switchport',
       'itd device-group udpGroup ; node ip 1.1.1.1',
     ].join(' ; ')
-    test_set(agent, cmd)
+    ctx.test_set(ctx.agent, cmd)
   end
 end
 

--- a/tests/beaker_tests/cisco_object_group/test_object_group.rb
+++ b/tests/beaker_tests/cisco_object_group/test_object_group.rb
@@ -64,20 +64,23 @@ tests[:seq_30_v4] = {
   },
 }
 
-def dependency_manifest(_tests, _id)
-  "
-    cisco_object_group { 'ipv4 address beaker':
-      ensure => present,
-    }
+# class to contain the test_dependencies specific to this test case
+class TestObjectGroup < BaseHarness
+  def self.dependency_manifest(_ctx, _tests, _id)
+    "
+      cisco_object_group { 'ipv4 address beaker':
+        ensure => present,
+      }
 
-    cisco_object_group { 'ipv6 address beaker6':
-      ensure => present,
-    }
+      cisco_object_group { 'ipv6 address beaker6':
+        ensure => present,
+      }
 
-    cisco_object_group { 'ipv4 port beakerp':
-      ensure => present,
-    }
-  "
+      cisco_object_group { 'ipv4 port beakerp':
+        ensure => present,
+      }
+    "
+  end
 end
 
 def cleanup

--- a/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
+++ b/tests/beaker_tests/cisco_overlay_global/test_overlay_global.rb
@@ -74,10 +74,10 @@ tests[:non_default] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestOverlayGlobal
-  def self.unsupported_properties(_tests, _id)
+class TestOverlayGlobal < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    if platform[/n3k$/]
+    if ctx.platform[/n3k$/]
       unprops <<
         :anycast_gateway_mac <<
         :dup_host_ip_addr_detection_host_moves <<
@@ -88,7 +88,7 @@ class TestOverlayGlobal
 
   def self.version_unsupported_properties(_tests, _id)
     unprops = {}
-    if platform[/n3k$/]
+    if ctx.platform[/n3k$/]
       unprops[:dup_host_mac_detection_host_moves] = '7.0.3.I6.1'
       unprops[:dup_host_mac_detection_timeout] = '7.0.3.I6.1'
     end

--- a/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
+++ b/tests/beaker_tests/cisco_portchannel_global/test_portchannel_global.rb
@@ -117,16 +117,16 @@ tests[:non_default][:manifest_props].merge!(manifest_non[:n9kf]) if platform[/n(
 tests[:non_default][:manifest_props].merge!(manifest_non[:n9k]) if platform[/n9k$/]
 
 # class to contain the test_dependencies specific to this test case
-class TestPortChannelGlobal
-  def self.unsupported_properties(tests, _id)
+class TestPortChannelGlobal < BaseHarness
+  def self.unsupported_properties(ctx, tests, _id)
     unprops = []
-    if platform[/n7k/]
+    if ctx.platform[/n7k/]
       unprops <<
         :concatenation <<
         :hash_poly <<
         :resilient <<
         :symmetry
-    elsif platform[/n(5|6)k/]
+    elsif ctx.platform[/n(5|6)k/]
       unprops <<
         :asymmetric <<
         :concatenation <<
@@ -135,7 +135,7 @@ class TestPortChannelGlobal
         :resilient <<
         :rotate <<
         :symmetry
-    elsif platform[/n(3|9)k-f/]
+    elsif ctx.platform[/n(3|9)k-f/]
       unprops <<
         :asymmetric <<
         :concatenation <<
@@ -144,7 +144,7 @@ class TestPortChannelGlobal
         :load_defer <<
         :resilient <<
         :symmetry
-    elsif platform[/n3k/]
+    elsif ctx.platform[/n3k/]
       unprops <<
         :asymmetric <<
         :concatenation <<
@@ -152,15 +152,14 @@ class TestPortChannelGlobal
         :hash_poly <<
         :load_defer <<
         :rotate
-    elsif platform[/n9k/]
+    elsif ctx.platform[/n9k/]
       unprops <<
         :asymmetric <<
         :hash_distribution <<
         :hash_poly <<
         :load_defer
     end
-    unprops << :resilient << :symmetry if
-      tests[:resilient_unsupported]
+    unprops << :resilient << :symmetry if tests[:resilient_unsupported]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_route_map/test_route_map.rb
+++ b/tests/beaker_tests/cisco_route_map/test_route_map.rb
@@ -527,38 +527,38 @@ def unsupp_n9kf
 end
 
 # class to contain the test_dependencies specific to this test case
-class TestRouteMap
-  def self.unsupported_properties(_tests, _id)
-    if platform[/n3k$/]
+class TestRouteMap < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
+    if ctx.platform[/n3k$/]
       unsupp_n3k
-    elsif platform[/n(5|6)k/]
+    elsif ctx.platform[/n(5|6)k/]
       unsupp_n56k
-    elsif platform[/n7k/]
+    elsif ctx.platform[/n7k/]
       unsupp_n7k
-    elsif platform[/n9k$|n9k-ex/]
+    elsif ctx.platform[/n9k$|n9k-ex/]
       unsupp_n9k
-    elsif platform[/n(3|9)k-f/]
+    elsif ctx.platform[/n(3|9)k-f/]
       unsupp_n9kf
     end
   end
 
   def self.version_unsupported_properties(_tests, _id)
     unprops = {}
-    if platform[/n(3|9)k-f/]
+    if ctx.platform[/n(3|9)k-f/]
       unprops[:match_metric] = '7.0.3.F2.1'
       unprops[:set_extcommunity_4bytes_additive] = '7.0.3.F2.1'
       unprops[:set_extcommunity_4bytes_non_transitive] = '7.0.3.F2.1'
       unprops[:set_extcommunity_4bytes_transitive] = '7.0.3.F2.1'
       unprops[:set_ipv4_next_hop_load_share] = '7.0.3.F2.1'
       unprops[:set_ipv6_next_hop_load_share] = '7.0.3.F2.1'
-    elsif platform[/n9k/]
+    elsif ctx.platform[/n9k/]
       unprops[:match_ospf_area] = '7.0.3.I5.1'
       unprops[:set_ipv4_next_hop_load_share] = '7.0.3.I5.1'
       unprops[:set_ipv6_next_hop_load_share] = '7.0.3.I5.1'
       unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
       unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'
       unprops[:set_community] = '7.0.3.I5.1'
-    elsif platform[/n3k/]
+    elsif ctx.platform[/n3k/]
       unprops[:match_ospf_area] = '7.0.3.I5.1'
       unprops[:set_ipv4_next_hop_redist] = '7.0.3.I5.1'
       unprops[:set_ipv6_next_hop_redist] = '7.0.3.I5.1'

--- a/tests/beaker_tests/cisco_snmp_server/test_snmp_server.rb
+++ b/tests/beaker_tests/cisco_snmp_server/test_snmp_server.rb
@@ -90,10 +90,10 @@ def cleanup(agent)
 end
 
 # class to contain the test_dependencies specific to this test case
-class TestSnmpServer
-  def self.unsupported_properties(*)
+class TestSnmpServer < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    unprops << :packet_size if image?[/7.0.3.I2|I3/] # CSCuz14217
+    unprops << :packet_size if ctx.image?[/7.0.3.I2|I3/] # CSCuz14217
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
+++ b/tests/beaker_tests/cisco_stp_global/test_stp_global.rb
@@ -209,29 +209,29 @@ tests[:non_default_bd] = {
 }
 
 # class to contain the harness_dependencies specific to these tests
-class TestStpGlobal
-  def self.test_harness_dependencies(_tests, id)
-    return unless platform == 'n7k'
+class TestStpGlobal < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, id)
+    return unless ctx.platform == 'n7k'
     if id == :default_bd || id == :non_default_bd
       cmd = 'system bridge-domain all'
-      command_config(agent, cmd, cmd)
+      ctx.command_config(ctx.agent, cmd, cmd)
     else
       cmd = 'system bridge-domain all ; system bridge-domain none'
-      command_config(agent, cmd, cmd)
+      ctx.command_config(ctx.agent, cmd, cmd)
     end
   end
 
-  def self.unsupported_properties(_tests, _id)
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    unprops << :domain if platform[/n(3|9)k-f/]
-    unprops << :fcoe if platform[/n(3|5|6|7)k/]
+    unprops << :domain if ctx.platform[/n(3|9)k-f/]
+    unprops << :fcoe if ctx.platform[/n(3|5|6|7)k/]
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:domain] = '7.0.3.I6.1' if platform[/n3k$/]
-    unprops[:domain] = '7.0.3.I6.1' if platform[/n9k$/]
+    unprops[:domain] = '7.0.3.I6.1' if ctx.platform[/n3k$/]
+    unprops[:domain] = '7.0.3.I6.1' if ctx.platform[/n9k$/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_vdc/test_vdc.rb
+++ b/tests/beaker_tests/cisco_vdc/test_vdc.rb
@@ -47,12 +47,12 @@ tests[:non_default] = {
 }
 
 # class to contain the test_harness_dependencies
-class TestVdc
-  def self.test_harness_dependencies(_tests, id)
+class TestVdc < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, id)
     return unless id == :non_default
 
     # Set module-type to default value
-    limit_resource_module_type_set(default_vdc_name, nil)
+    ctx.limit_resource_module_type_set(ctx.default_vdc_name, nil)
   end
 end
 

--- a/tests/beaker_tests/cisco_vlan/test_vlan.rb
+++ b/tests/beaker_tests/cisco_vlan/test_vlan.rb
@@ -110,13 +110,13 @@ if platform[/n3k$/]
 end
 
 # class to contain the test_dependencies specific to this test case
-class TestVlan
-  def self.unsupported_properties(tests, _id)
+class TestVlan < BaseHarness
+  def self.unsupported_properties(ctx, tests, _id)
     unprops = []
 
-    unprops << :mapped_vni if platform[/n7k/] || tests[:vn_segment_unsupported]
+    unprops << :mapped_vni if ctx.platform[/n7k/] || tests[:vn_segment_unsupported]
 
-    unprops << :fabric_control unless platform[/n7k/]
+    unprops << :fabric_control unless ctx.platform[/n7k/]
 
     logger.info("  unprops: #{unprops}") unless unprops.empty?
     unprops

--- a/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
+++ b/tests/beaker_tests/cisco_vpc_domain/test_vpc_domain.rb
@@ -174,11 +174,11 @@ tests[:vpc_plus_non_default_properties_n7k] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestVpcDomain
-  def self.version_unsupported_properties(_tests, _id)
+class TestVpcDomain < BaseHarness
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:layer3_peer_routing] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
-    unprops[:shutdown] = '7.0.3.I6.1' if platform[/n(3|9)k$/]
+    unprops[:layer3_peer_routing] = '7.0.3.I6.1' if ctx.platform[/n(3|9)k$/]
+    unprops[:shutdown] = '7.0.3.I6.1' if ctx.platform[/n(3|9)k$/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_vrf/test_vrf.rb
+++ b/tests/beaker_tests/cisco_vrf/test_vrf.rb
@@ -65,19 +65,19 @@ tests[:non_default] = {
 }
 
 # class to contain the test_dependencies specific to this test case
-class TestVrf
-  def self.unsupported_properties(_tests, _id)
+class TestVrf < BaseHarness
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    if operating_system == 'nexus'
+    if ctx.operating_system == 'nexus'
       unprops <<
         :mhost_ipv4_default_interface <<
         :mhost_ipv6_default_interface <<
         :remote_route_filtering <<
         :vpn_id
 
-      unprops << :vni unless platform[/n9k/]
-      unprops << :route_distinguisher if nexus_image['I2']
-      unprops << :description if image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
+      unprops << :vni unless ctx.platform[/n9k/]
+      unprops << :route_distinguisher if ctx.nexus_image['I2']
+      unprops << :description if ctx.image?[/7.3.0.D1.1|7.3.0.N1.1/] # CSCuy36637
 
     else
       unprops <<
@@ -88,14 +88,14 @@ class TestVrf
     logger.info("  unprops: #{unprops}") unless unprops.empty?
     unprops
   end
-end
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(_tests, id)
-  return unless id[/non_default/]
-  dep = %( cisco_interface {'loopback100': ensure => 'present' } )
-  logger.info("\n  * dependency_manifest\n#{dep}")
-  dep
+  # Overridden to properly handle dependencies for this test file.
+  def self.dependency_manifest(ctx, _tests, id)
+    return unless id[/non_default/]
+    dep = %( cisco_interface {'loopback100': ensure => 'present' } )
+    ctx.logger.info("\n  * dependency_manifest\n#{dep}")
+    dep
+  end
 end
 
 #################################################################

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_defaults.rb
@@ -63,8 +63,7 @@ testheader = 'VTP Resource :: All Attributes Defaults'
 
 # @test_name [TestCase] Executes defaults testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
-  raise_skip_exception('Not supported on fretta', self) if
-    platform[/n(3|9)k-f/]
+  raise_skip_exception('Not supported on fretta', self) if platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_negatives.rb
@@ -61,8 +61,7 @@ testheader = 'VTP Resource :: All Attributes Negatives'
 
 # @test_name [TestCase] Executes negatives testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
-  raise_skip_exception('Not supported on fretta', self) if
-    platform[/n(3|9)k-f/]
+  raise_skip_exception('Not supported on fretta', self) if platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
+++ b/tests/beaker_tests/cisco_vtp/vtp_provider_nondefaults.rb
@@ -63,8 +63,7 @@ testheader = 'VTP Resource :: All Attributes NonDefaults'
 
 # @test_name [TestCase] Executes nondefaults testcase for VTP Resource.
 test_name "TestCase :: #{testheader}" do
-  raise_skip_exception('Not supported on fretta', self) if
-    platform[/n(3|9)k-f/]
+  raise_skip_exception('Not supported on fretta', self) if platform[/n(3|9)k-f/]
   # @step [Step] Sets up switch for provider test.
   step 'TestStep :: Setup switch for provider test' do
     resource_absent_cleanup(agent, 'cisco_vtp', 'Setup for vtp test')

--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -65,27 +65,27 @@ tests[:non_default] = {
 }
 
 # class to contain the test_harness_dependencies
-class TestVxlanVtep
-  def self.test_harness_dependencies(*)
-    test_set(agent, 'evpn multisite border 150') if platform[/ex/]
-    return unless platform[/n(5|6)k/]
-    skip_if_nv_overlay_rejected(agent)
+class TestVxlanVtep < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, _id)
+    ctx.test_set(ctx.agent, 'evpn multisite border 150') if ctx.platform[/ex/]
+    return unless ctx.platform[/n(5|6)k/]
+    ctx.skip_if_nv_overlay_rejected(ctx.agent)
 
     # Vxlan has a hard requirement to disable feature fabricpath on n5/6k
     cmd = 'no feature-set fabricpath'
-    command_config(agent, cmd, cmd)
+    ctx.command_config(ctx.agent, cmd, cmd)
   end
 
-  def self.unsupported_properties(*)
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    unprops << :source_interface_hold_down_time if platform[/n(5|6)k/]
-    unprops << :multisite_border_gateway_interface unless platform[/ex/]
+    unprops << :source_interface_hold_down_time if ctx.platform[/n(5|6)k/]
+    unprops << :multisite_border_gateway_interface unless ctx.platform[/ex/]
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:source_interface_hold_down_time] = '8.1.1' if platform[/n7k/]
+    unprops[:source_interface_hold_down_time] = '8.1.1' if ctx.platform[/n7k/]
     unprops
   end
 end

--- a/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep_vni/test_vxlan_vtep_vni.rb
@@ -250,52 +250,52 @@ tests[:multisite_ingress_replication_false] = {
 # will be added here.
 
 # class to contain the test_harness_dependencies
-class TestVxLanVtepVni
-  def self.test_harness_dependencies(*)
-    test_set(agent, 'evpn multisite border 150') if platform[/ex/]
-    return unless platform[/n(5|6)k/]
-    skip_if_nv_overlay_rejected(agent)
+class TestVxLanVtepVni < BaseHarness
+  def self.test_harness_dependencies(ctx, _tests, _id)
+    ctx.test_set(ctx.agent, 'evpn multisite border 150') if ctx.platform[/ex/]
+    return unless ctx.platform[/n(5|6)k/]
+    ctx.skip_if_nv_overlay_rejected(ctx.agent)
   end
 
-  def unsupported_properties(_tests, _id)
+  def self.unsupported_properties(ctx, _tests, _id)
     unprops = []
-    if platform[/n(3k-f|5k|6k|7k|9k-f)/]
+    if ctx.platform[/n(3k-f|5k|6k|7k|9k-f)/]
       unprops <<
         :ingress_replication <<
         :peer_list
     end
-    if platform[/n(3k-f|9k)/]
+    if ctx.platform[/n(3k-f|9k)/]
       unprops <<
         :suppress_uuc
     end
-    unprops << :multisite_ingress_replication unless platform[/ex/]
+    unprops << :multisite_ingress_replication unless ctx.platform[/ex/]
     unprops
   end
 
-  def self.version_unsupported_properties(_tests, _id)
+  def self.version_unsupported_properties(ctx, _tests, _id)
     unprops = {}
-    unprops[:suppress_uuc] = '8.1.1' if platform[/n7k/]
+    unprops[:suppress_uuc] = '8.1.1' if ctx.platform[/n7k/]
     unprops
   end
-end
 
-# Overridden to properly handle dependencies for this test file.
-def dependency_manifest(_tests, _id)
-  if platform[/n7k/]
-    "
-      cisco_vxlan_vtep {'nve1':
-        ensure => present,
-        host_reachability => 'evpn',
-        shutdown           => 'false',
-      }
-    "
-  else
-    "
-      cisco_vxlan_vtep {'nve1':
-        ensure => present,
-        shutdown           => 'false',
-      }
-    "
+  # Overridden to properly handle dependencies for this test file.
+  def self.dependency_manifest(ctx, _tests, _id)
+    if ctx.platform[/n7k/]
+      "
+        cisco_vxlan_vtep {'nve1':
+          ensure => present,
+          host_reachability => 'evpn',
+          shutdown           => 'false',
+        }
+      "
+    else
+      "
+        cisco_vxlan_vtep {'nve1':
+          ensure => present,
+          shutdown           => 'false',
+        }
+      "
+    end
   end
 end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -55,1697 +55,1732 @@ TEMP_AGENTLESS_MANIFEST_PREFIX = 'temp_test_apply'
 # testing the presence of a key, regardless of value)
 IGNORE_VALUE = :ignore_value
 
-# Current agentless nexus host
-@nexus_host = nil
-
-# Method to create agentless device.conf and
-# appropriate credentials.conf
-#
-# Assumes that the beaker configuration contains a Nexus host with role default
-# Raises an error if not the case.
-def create_agentless_device_conf
-  raise 'Could not find default Nexus host' unless default && default.host_hash[:platform].match(%r{cisco_nexus.*})
-  @nexus_host = default
-
-  credentials_file = 'spec/fixtures/acceptance-credentials.conf'
-  device_conf_file = 'spec/fixtures/acceptance-device.conf'
-
-  if File.exist?(credentials_file)
-    File.delete(credentials_file)
-  end
-  if File.exist?(device_conf_file)
-    File.delete(device_conf_file)
+# A simple baseclass for test harnesses, following the NullObject pattern
+# Using this alleviates the necessity of checking for presence or capabilities of
+# the harness class.
+class BaseHarness
+  # This method returns a string representation of a manifest that contains
+  # any dependencies needed for a particular test to run.
+  # Override this in a particular test file as needed.
+  def self.dependency_manifest(_ctx, _tests, _id)
+    nil # indicates no manifest dependencies
   end
 
-  File.open(credentials_file, 'w') do |file|
-    file.puts <<CREDENTIALS
+  # This method is used for additional testbed setup beyond the basics
+  # used by most tests.
+  # Override this in a particular test file as needed.
+  def self.test_harness_dependencies(_ctx, _tests, _id)
+    # default is to do nothing
+  end
+
+  # Returns an array of properties that are not supported for
+  # a particular operating_system or platform.
+  # Override this in a particular test file as needed.
+  def self.unsupported_properties(_ctx, _tests, _id)
+    [] # defaults to no unsupported properties
+  end
+
+  # Returns an array of properties that are not supported for
+  # a particular operating_system or platform for a particular
+  # software version.
+  # Override this in a particular test file as needed.
+  # Ex: If property 'ipv4_sub_option_circuit_id_string' is
+  # supported on n9k only on version '7.0.3.I6.1' or higher
+  # then add this line in the overridden method.
+  # unprops[:ipv4_sub_option_circuit_id_string] = '7.0.3.I6.1' if
+  #   platform[/n9k$/]
+  def self.version_unsupported_properties(_ctx, _tests, _id)
+    {} # defaults to no version_unsupported properties
+  end
+end
+
+# Monkeypatch all our utility functions into beaker's TestCase, so that we don't poison the global namespace
+class Beaker::TestCase
+  # Current agentless nexus host
+  @nexus_host = nil
+
+  # Method to create agentless device.conf and
+  # appropriate credentials.conf
+  #
+  # Assumes that the beaker configuration contains a Nexus host with role default
+  # Raises an error if not the case.
+  def create_agentless_device_conf
+    raise 'Could not find default Nexus host' unless default && default.host_hash[:platform].match(%r{cisco_nexus.*})
+    @nexus_host = default
+
+    credentials_file = 'spec/fixtures/acceptance-credentials.conf'
+    device_conf_file = 'spec/fixtures/acceptance-device.conf'
+
+    if File.exist?(credentials_file)
+      File.delete(credentials_file)
+    end
+    if File.exist?(device_conf_file)
+      File.delete(device_conf_file)
+    end
+
+    File.open(credentials_file, 'w') do |file|
+      file.puts <<CREDENTIALS
 address: "#{@nexus_host.host_hash[:vmhostname]}"
 username: "#{@nexus_host.host_hash[:ssh][:user] || 'admin'}"
 port: "#{@nexus_host.host_hash[:ssh][:port] || '22'}"
 password: "#{@nexus_host.host_hash[:ssh][:password] || 'admin'}"
 CREDENTIALS
-  end
+    end
 
-  File.open(device_conf_file, 'w') do |file|
-    file.puts <<DEVICE
+    File.open(device_conf_file, 'w') do |file|
+      file.puts <<DEVICE
 [sut]
 type cisco_nexus
 url file://#{Dir.getwd}/spec/fixtures/acceptance-credentials.conf
 DEVICE
-  end
-end
-
-# Method to return an agent
-# Otherwise, if running agentlessly, call the device configuration creation method
-# if not already called
-def agent
-  agent_host = find_host_with_role :agent
-  if agent_host.nil?
-    if @nexus_host.nil?
-      create_agentless_device_conf
     end
-    return nil
-  else
-    agent_host
   end
-end
 
-# These methods are defined outside of a module so that
-# they can access the Beaker DSL API's.
-
-# Method to return the Vegas shell command string for a NXOS CLI command.
-# @param nxosclistr [String] The NXOS CLI command string to execute on host.
-# @result vshellcmd [String] Returns 'vsh -c <cmd>' command string.
-def get_vshell_cmd(nxosclistr)
-  "/isan/bin/vsh -c '#{nxosclistr}'"
-end
-
-# Method to parse a Hash literal into an array of RegExp literals.
-# @param hash [hash] Comma-separated list of key/value pairs.
-# @result regexparr [Array] Array of RegExp literals.
-def hash_to_patterns(hash)
-  regexparr = []
-  hash.each do |key, value|
-    if value == IGNORE_VALUE
-      regexparr << Regexp.new("#{key}\s+=>?")
-      next
-    end
-    value = value.to_s
-    # Need to escape '[', ']', '"' characters for nested array of arrays.
-    # Example:
-    #   [["192.168.5.0/24", "nrtemap1"], ["192.168.6.0/32"]]
-    # Becomes:
-    #   \[\['192.168.5.0\/24', 'nrtemap1'\], \['192.168.6.0\/32'\]\]
-    if /^\[.*\]$/.match(value)
-      # Handle Puppet 5 line wrap issue
-      value.gsub!(/^[\[]/, '[\n? *').gsub!(', [', ',\n? +?[')
-      # END Handle Puppet 5 line wrap issue
-      value.gsub!(/[\[\]]/) { |s| '\\' + "#{s}" }.gsub!(/\"/) { |_s| '\'' }
-    end
-    value.gsub!(/[\(\)]/) { |s| '\\' + "#{s}" } if /\(.*\)/.match(value)
-    regexparr << Regexp.new("#{key}\s+=>\s+'?#{value}'?")
-  end
-  regexparr
-end
-
-# Method to check if RegExp pattern array exists in Beaker::Result object's
-# stdout or output instance attributes.
-# @param output [IO] IO attribute output or stdout of Result object.
-# @param patarr [Array, Hash] Array of RegExp patterns or Hash of key/value
-# pairs to search in output object.
-# @param inverse [Boolean] Boolean flag to indicate Boolean NOT matching op.
-# @param testcase [TestCase] An instance of Beaker::TestCase.
-# @param logger [Logger] A default instance of Beaker::Logger.
-# @result none [None] Returns no object.
-def search_pattern_in_output(output, patarr, inverse, testcase,\
-                             logger)
-  patarr = hash_to_patterns(patarr) if patarr.instance_of?(Hash)
-  patarr.each do |pattern|
-    inverse ? (match = (output !~ pattern)) : (match = (output =~ pattern))
-    match_kind = inverse ? 'Inverse ' : ''
-    if match
-      logger.debug("TestStep :: #{match_kind}Match #{pattern} :: PASS")
+  # Method to return an agent
+  # Otherwise, if running agentlessly, call the device configuration creation method
+  # if not already called
+  def agent
+    agent_host = find_host_with_role :agent
+    if agent_host.nil?
+      if @nexus_host.nil?
+        create_agentless_device_conf
+      end
+      return nil
     else
-      logger.error("stdout:\n--\n#{stdout}\n--")
-      testcase.fail_test("TestStep :: #{match_kind}Match #{pattern} :: FAIL")
+      agent_host
     end
   end
-end
 
-# Method to raise and handle Beaker::DSL::Outcomes::PassTest or
-# Beaker::DSL::Outcomes::FailTest exception based on testresult value.
-# @param testresult [String] String object set to 'PASS' or 'FAIL'.
-# @param message [String] String object to represent testcase.
-# @param testcase [TestCase] An instance of Beaker::TestCase.
-# @param logger [Logger] A default instance of Beaker::Logger.
-# @result none [None] Returns no object.
-def raise_passfail_exception(testresult, message, testcase, logger)
-  if testresult == 'PASS'
-    testcase.pass_test("\nTestCase :: #{message} :: PASS")
-  else
-    testcase.fail_test("\nTestCase :: #{message} :: FAIL")
+  # These methods are defined outside of a module so that
+  # they can access the Beaker DSL API's.
+
+  # Method to return the Vegas shell command string for a NXOS CLI command.
+  # @param nxosclistr [String] The NXOS CLI command string to execute on host.
+  # @result vshellcmd [String] Returns 'vsh -c <cmd>' command string.
+  def get_vshell_cmd(nxosclistr)
+    "/isan/bin/vsh -c '#{nxosclistr}'"
   end
-rescue Beaker::DSL::Outcomes::PassTest
-  logger.success("TestCase :: #{message} :: PASS")
-rescue Beaker::DSL::Outcomes::FailTest
-  logger.error("TestCase :: #{message} :: FAIL")
-end
 
-# Raise a Beaker::DSL::Outcomes::SkipTest exception.
-# @param message [String] String object to represent testcase.
-# @param testcase [TestCase] An instance of Beaker::TestCase.
-# @result none [None] Returns no object.
-def raise_skip_exception(message, testcase)
-  testcase.skip_test("\nTestCase :: #{message} :: SKIP")
-end
-
-# Full command string for puppet agent
-def puppet_agent_cmd
-  PUPPET_BINPATH + 'agent -t --trace'
-end
-
-# Auto generation of properties for manifests
-# attributes: hash of property names and values
-# return: a manifest friendly string of property names / values
-def prop_hash_to_manifest(attributes)
-  return '' if attributes.nil?
-  manifest_str = ''
-  attributes.each do |k, v|
-    next if v.nil?
-    if v.is_a?(String)
-      manifest_str += sprintf("    %-40s => '#{v.strip}',\n", k)
-    else
-      manifest_str += sprintf("    %-40s => #{v},\n", k)
+  # Method to parse a Hash literal into an array of RegExp literals.
+  # @param hash [hash] Comma-separated list of key/value pairs.
+  # @result regexparr [Array] Array of RegExp literals.
+  def hash_to_patterns(hash)
+    regexparr = []
+    hash.each do |key, value|
+      if value == IGNORE_VALUE
+        regexparr << Regexp.new("#{key}\s+=>?")
+        next
+      end
+      value = value.to_s
+      # Need to escape '[', ']', '"' characters for nested array of arrays.
+      # Example:
+      #   [["192.168.5.0/24", "nrtemap1"], ["192.168.6.0/32"]]
+      # Becomes:
+      #   \[\['192.168.5.0\/24', 'nrtemap1'\], \['192.168.6.0\/32'\]\]
+      if /^\[.*\]$/.match(value)
+        # Handle Puppet 5 line wrap issue
+        value.gsub!(/^[\[]/, '[\n? *').gsub!(', [', ',\n? +?[')
+        # END Handle Puppet 5 line wrap issue
+        value.gsub!(/[\[\]]/) { |s| '\\' + "#{s}" }.gsub!(/\"/) { |_s| '\'' }
+      end
+      value.gsub!(/[\(\)]/) { |s| '\\' + "#{s}" } if /\(.*\)/.match(value)
+      regexparr << Regexp.new("#{key}\s+=>\s+'?#{value}'?")
     end
+    regexparr
   end
-  manifest_str
-end
 
-# Wrapper for processing all tests for each test scenario.
-#
-# Inputs:
-# tests - a hash of control values
-# id - identifies the specific test case hash key
-#
-# Top-level keys set by caller:
-# tests[:master] - the master object
-# tests[:agent] - the agent object
-#
-# tests[id] keys set by caller:
-# tests[id][:desc] - a string to use with logs & debugs
-# tests[id][:manifest] - the complete manifest, as used by test_harness_common
-# tests[id][:resource] - a hash of expected states, used by test_resource
-# tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
-# tests[id][:ensure] - (Optional) set to :present or :absent before calling
-# tests[id][:code] - (Optional) override the default exit code in some tests.
-#
-# Reserved keys
-# tests[id][:log_desc] - the final form of the log description
-#
-def test_harness_common(tests, id, harness_class: nil, skip_idempotence_check: false)
-  tests[id][:ensure] = :present if tests[id][:ensure].nil?
-  tests[id][:state] = false if tests[id][:state].nil?
-  tests[id][:desc] = '' if tests[id][:desc].nil?
-  tests[id][:log_desc] = tests[id][:desc] + " [ensure => #{tests[id][:ensure]}]"
-  logger.info("\n--------\n#{tests[id][:log_desc]}")
-
-  test_manifest(tests, id)
-  test_resource(tests, id, harness_class: harness_class)
-  test_idempotence(tests, id) unless skip_idempotence_check
-  remove_temp_manifest
-  tests[id].delete(:log_desc)
-end
-
-# Wrapper for formatting test log entries
-def format_stepinfo(tests, id, test_str)
-  logger.debug("format_stepinfo :: (#{tests[id][:desc]}) (#{test_str})")
-  tests[id][:log_desc] = tests[id][:desc] if tests[id][:log_desc].nil?
-  tests[id][:log_desc] + sprintf(' :: %-12s', test_str)
-end
-
-# helper to match stderr buffer against :stderr_pattern
-def test_stderr(tests, id)
-  if stderr =~ tests[id][:stderr_pattern]
-    logger.debug("TestStep :: Match #{tests[id][:stderr_pattern]} :: PASS")
-  else
-    fail_test("TestStep :: Match #{tests[id][:stderr_pattern]} :: FAIL")
-  end
-end
-
-# Function to remove the temporary manifest
-def remove_temp_manifest(manifest=@temp_agentless_manifest)
-  return unless manifest
-  manifest.close
-  manifest.unlink
-end
-
-# Wrapper for manifest tests
-# Pass code = [0], as an alternative to 'test_idempotence'
-def test_manifest(tests, id)
-  stepinfo = format_stepinfo(tests, id, 'MANIFEST')
-  step "TestStep :: #{stepinfo}" do
-    logger.debug("test_manifest :: manifest:\n#{tests[id][:manifest]}")
-    if tests[:master]
-      on(tests[:master], tests[id][:manifest])
-      code = (tests[id][:code]) ? tests[id][:code] : [2]
-      logger.debug("test_manifest :: check puppet agent cmd (code: #{code})")
-      on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: code)
-    else
-      code = (tests[id][:code]) ? tests[id][:code] : [2]
-      logger.debug("test_manifest :: check puppet apply cmd (code: #{code})")
-      # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
-      # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
-      # if !code.include?($?.exitstatus)
-      #  raise 'Errored test'
-      # end
-      output = `#{AGENTLESS_COMMAND} --apply #{@temp_agentless_manifest.path}`
-      unless output.include? 'Applied catalog'
-        remove_temp_manifest
-        raise 'Errored test'
+  # Method to check if RegExp pattern array exists in Beaker::Result object's
+  # stdout or output instance attributes.
+  # @param output [IO] IO attribute output or stdout of Result object.
+  # @param patarr [Array, Hash] Array of RegExp patterns or Hash of key/value
+  # pairs to search in output object.
+  # @param inverse [Boolean] Boolean flag to indicate Boolean NOT matching op.
+  # @param testcase [TestCase] An instance of Beaker::TestCase.
+  # @param logger [Logger] A default instance of Beaker::Logger.
+  # @result none [None] Returns no object.
+  def search_pattern_in_output(output, patarr, inverse, testcase,\
+                               logger)
+    patarr = hash_to_patterns(patarr) if patarr.instance_of?(Hash)
+    patarr.each do |pattern|
+      inverse ? (match = (output !~ pattern)) : (match = (output =~ pattern))
+      match_kind = inverse ? 'Inverse ' : ''
+      if match
+        logger.debug("TestStep :: #{match_kind}Match #{pattern} :: PASS")
+      else
+        logger.error("stdout:\n--\n#{stdout}\n--")
+        testcase.fail_test("TestStep :: #{match_kind}Match #{pattern} :: FAIL")
       end
     end
-    test_stderr(tests, id) if tests[id][:stderr_pattern]
   end
-  logger.info("#{stepinfo} :: PASS")
-  tests[id].delete(:log_desc)
-end
 
-# Wrapper for 'puppet resource' command tests
-def test_resource(tests, id, harness_class: nil, state: false)
-  stepinfo = format_stepinfo(tests, id, 'RESOURCE')
-  step "TestStep :: #{stepinfo}" do
-    logger.debug("test_resource :: cmd:\n#{tests[id][:resource_cmd]}")
-    if tests[:agent]
-      on(tests[:agent], tests[id][:resource_cmd]) do
+  # Method to raise and handle Beaker::DSL::Outcomes::PassTest or
+  # Beaker::DSL::Outcomes::FailTest exception based on testresult value.
+  # @param testresult [String] String object set to 'PASS' or 'FAIL'.
+  # @param message [String] String object to represent testcase.
+  # @param testcase [TestCase] An instance of Beaker::TestCase.
+  # @param logger [Logger] A default instance of Beaker::Logger.
+  # @result none [None] Returns no object.
+  def raise_passfail_exception(testresult, message, testcase, logger)
+    if testresult == 'PASS'
+      testcase.pass_test("\nTestCase :: #{message} :: PASS")
+    else
+      testcase.fail_test("\nTestCase :: #{message} :: FAIL")
+    end
+  rescue Beaker::DSL::Outcomes::PassTest
+    logger.success("TestCase :: #{message} :: PASS")
+  rescue Beaker::DSL::Outcomes::FailTest
+    logger.error("TestCase :: #{message} :: FAIL")
+  end
+
+  # Raise a Beaker::DSL::Outcomes::SkipTest exception.
+  # @param message [String] String object to represent testcase.
+  # @param testcase [TestCase] An instance of Beaker::TestCase.
+  # @result none [None] Returns no object.
+  def raise_skip_exception(message, testcase)
+    testcase.skip_test("\nTestCase :: #{message} :: SKIP")
+  end
+
+  # Full command string for puppet agent
+  def puppet_agent_cmd
+    PUPPET_BINPATH + 'agent -t --trace'
+  end
+
+  # Auto generation of properties for manifests
+  # attributes: hash of property names and values
+  # return: a manifest friendly string of property names / values
+  def prop_hash_to_manifest(attributes)
+    return '' if attributes.nil?
+    manifest_str = ''
+    attributes.each do |k, v|
+      next if v.nil?
+      if v.is_a?(String)
+        manifest_str += sprintf("    %-40s => '#{v.strip}',\n", k)
+      else
+        manifest_str += sprintf("    %-40s => #{v},\n", k)
+      end
+    end
+    manifest_str
+  end
+
+  # Wrapper for processing all tests for each test scenario.
+  #
+  # Inputs:
+  # tests - a hash of control values
+  # id - identifies the specific test case hash key
+  #
+  # Top-level keys set by caller:
+  # tests[:master] - the master object
+  # tests[:agent] - the agent object
+  #
+  # tests[id] keys set by caller:
+  # tests[id][:desc] - a string to use with logs & debugs
+  # tests[id][:manifest] - the complete manifest, as used by test_harness_common
+  # tests[id][:resource] - a hash of expected states, used by test_resource
+  # tests[id][:resource_cmd] - 'puppet resource' command to use with test_resource
+  # tests[id][:ensure] - (Optional) set to :present or :absent before calling
+  # tests[id][:code] - (Optional) override the default exit code in some tests.
+  #
+  # Reserved keys
+  # tests[id][:log_desc] - the final form of the log description
+  #
+  def test_harness_common(tests, id, harness_class: BaseHarness, skip_idempotence_check: false)
+    tests[id][:ensure] = :present if tests[id][:ensure].nil?
+    tests[id][:state] = false if tests[id][:state].nil?
+    tests[id][:desc] = '' if tests[id][:desc].nil?
+    tests[id][:log_desc] = tests[id][:desc] + " [ensure => #{tests[id][:ensure]}]"
+    logger.info("\n--------\n#{tests[id][:log_desc]}")
+
+    test_manifest(tests, id)
+    test_resource(tests, id, harness_class: harness_class)
+    test_idempotence(tests, id) unless skip_idempotence_check
+    remove_temp_manifest
+    tests[id].delete(:log_desc)
+  end
+
+  # Wrapper for formatting test log entries
+  def format_stepinfo(tests, id, test_str)
+    logger.debug("format_stepinfo :: (#{tests[id][:desc]}) (#{test_str})")
+    tests[id][:log_desc] = tests[id][:desc] if tests[id][:log_desc].nil?
+    tests[id][:log_desc] + sprintf(' :: %-12s', test_str)
+  end
+
+  # helper to match stderr buffer against :stderr_pattern
+  def test_stderr(tests, id)
+    if stderr =~ tests[id][:stderr_pattern]
+      logger.debug("TestStep :: Match #{tests[id][:stderr_pattern]} :: PASS")
+    else
+      fail_test("TestStep :: Match #{tests[id][:stderr_pattern]} :: FAIL")
+    end
+  end
+
+  # Function to remove the temporary manifest
+  def remove_temp_manifest(manifest=@temp_agentless_manifest)
+    return unless manifest
+    manifest.close
+    manifest.unlink
+  end
+
+  # Wrapper for manifest tests
+  # Pass code = [0], as an alternative to 'test_idempotence'
+  def test_manifest(tests, id)
+    stepinfo = format_stepinfo(tests, id, 'MANIFEST')
+    step "TestStep :: #{stepinfo}" do
+      logger.debug("test_manifest :: manifest:\n#{tests[id][:manifest]}")
+      if tests[:master]
+        on(tests[:master], tests[id][:manifest])
+        code = (tests[id][:code]) ? tests[id][:code] : [2]
+        logger.debug("test_manifest :: check puppet agent cmd (code: #{code})")
+        on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: code)
+      else
+        code = (tests[id][:code]) ? tests[id][:code] : [2]
+        logger.debug("test_manifest :: check puppet apply cmd (code: #{code})")
+        # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
+        # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
+        # if !code.include?($?.exitstatus)
+        #  raise 'Errored test'
+        # end
+        output = `#{AGENTLESS_COMMAND} --apply #{@temp_agentless_manifest.path}`
+        unless output.include? 'Applied catalog'
+          remove_temp_manifest
+          raise 'Errored test'
+        end
+      end
+      test_stderr(tests, id) if tests[id][:stderr_pattern]
+    end
+    logger.info("#{stepinfo} :: PASS")
+    tests[id].delete(:log_desc)
+  end
+
+  # Wrapper for 'puppet resource' command tests
+  def test_resource(tests, id, harness_class: BaseHarness, state: false)
+    stepinfo = format_stepinfo(tests, id, 'RESOURCE')
+    step "TestStep :: #{stepinfo}" do
+      logger.debug("test_resource :: cmd:\n#{tests[id][:resource_cmd]}")
+      if tests[:agent]
+        on(tests[:agent], tests[id][:resource_cmd]) do
+          search_pattern_in_output(
+            stdout, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
+            state, self, logger
+          )
+        end
+      else
+        output = `#{tests[id][:resource_cmd]}`
         search_pattern_in_output(
-          stdout, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
+          output, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
           state, self, logger
         )
       end
-    else
-      output = `#{tests[id][:resource_cmd]}`
-      search_pattern_in_output(
-        output, supported_property_hash(tests, id, tests[id][:resource], harness_class: harness_class),
-        state, self, logger
-      )
+      logger.info("#{stepinfo} :: PASS")
+      tests[id].delete(:log_desc)
     end
-    logger.info("#{stepinfo} :: PASS")
-    tests[id].delete(:log_desc)
   end
-end
 
-# Wrapper for idempotency tests
-def test_idempotence(tests, id)
-  stepinfo = format_stepinfo(tests, id, 'IDEMPOTENCE')
-  step "TestStep :: #{stepinfo}" do
-    logger.debug('test_idempotence :: BEGIN')
-    if tests[:agent]
-      on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: [0])
-    else
-      # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
-      # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
-      # if !$?.exitstatus == 0
-      #   raise 'Errored idempotence test'
-      # end
-      output = `#{AGENTLESS_COMMAND} --apply #{@temp_agentless_manifest.path}`
-      if output.include? "#{tests[:resource_name]}[#{tests[id][:title_pattern]}]: Updating:"
-        raise 'Errored idempotence test'
-      end
-    end
-    logger.info("#{stepinfo} :: PASS")
-    tests[id].delete(:log_desc)
-  end
-end
-
-# Helper to retrieve all instances of a given resource
-# @param agent [String] the agent to be queried
-# @param res_name [String] the resource to retrieve instances of
-# @return [Array] an array of string names of instances
-def get_current_resource_instances(agent, res_name)
-  if agent
-    cmd_str = PUPPET_BINPATH + "resource #{res_name}"
-    on(agent, cmd_str, acceptable_exit_codes: [0])
-    names = stdout.scan(/#{res_name} { '(.+)':/).flatten
-  else
-    output = `#{AGENTLESS_COMMAND} --resource #{res_name}`
-    names = output.scan(/#{res_name} { '(.+)':/).flatten
-  end
-  names
-end
-
-# Method to clean *all* resources of a given resource name, by
-# calling puppet resource with 'ensure=absent'.
-# @param agent [String] the agent that is going to run the test
-# @param res_name [String] the resource name that will be cleaned up
-def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
-  step "\n--------\n * TestStep :: #{stepinfo}" do
-    # set each resource to ensure=absent
-    get_current_resource_instances(agent, res_name).each do |title|
-      # Some resources have exceptions
-      case res_name
-      when /cisco_bgp$/
-        # cleaning default cleans them all
-        next unless title[/default/]
-      when /^cisco_interface$/
-        next if title[/ethernet/i]
-      when /cisco_snmp_user/
-        next if title[/devops/i]
-      when /cisco_vlan/
-        # TBD: Per-vlan cleanup is too slow. Consider 'no vlan 1-4095'
-        next if title == '1'
-      when /cisco_vrf/
-        next if title[/management/]
-      end
-      logger.info("  * #{stepinfo} Removing #{res_name} '#{title}'")
-      if agent
-        cmd_str = PUPPET_BINPATH + "resource #{res_name} '#{title}' ensure=absent"
-        on(agent, cmd_str, acceptable_exit_codes: [0])
+  # Wrapper for idempotency tests
+  def test_idempotence(tests, id)
+    stepinfo = format_stepinfo(tests, id, 'IDEMPOTENCE')
+    step "TestStep :: #{stepinfo}" do
+      logger.debug('test_idempotence :: BEGIN')
+      if tests[:agent]
+        on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: [0])
       else
-        create_and_apply_test_manifest(res_name, title, 'ensure', 'absent')
+        # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
+        # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
+        # if !$?.exitstatus == 0
+        #   raise 'Errored idempotence test'
+        # end
+        output = `#{AGENTLESS_COMMAND} --apply #{@temp_agentless_manifest.path}`
+        if output.include? "#{tests[:resource_name]}[#{tests[id][:title_pattern]}]: Updating:"
+          raise 'Errored idempotence test'
+        end
+      end
+      logger.info("#{stepinfo} :: PASS")
+      tests[id].delete(:log_desc)
+    end
+  end
+
+  # Helper to retrieve all instances of a given resource
+  # @param agent [String] the agent to be queried
+  # @param res_name [String] the resource to retrieve instances of
+  # @return [Array] an array of string names of instances
+  def get_current_resource_instances(agent, res_name)
+    if agent
+      cmd_str = PUPPET_BINPATH + "resource #{res_name}"
+      on(agent, cmd_str, acceptable_exit_codes: [0])
+      names = stdout.scan(/#{res_name} { '(.+)':/).flatten
+    else
+      output = `#{AGENTLESS_COMMAND} --resource #{res_name}`
+      names = output.scan(/#{res_name} { '(.+)':/).flatten
+    end
+    names
+  end
+
+  # Method to clean *all* resources of a given resource name, by
+  # calling puppet resource with 'ensure=absent'.
+  # @param agent [String] the agent that is going to run the test
+  # @param res_name [String] the resource name that will be cleaned up
+  def resource_absent_cleanup(agent, res_name, stepinfo='absent clean')
+    step "\n--------\n * TestStep :: #{stepinfo}" do
+      # set each resource to ensure=absent
+      get_current_resource_instances(agent, res_name).each do |title|
+        # Some resources have exceptions
+        case res_name
+        when /cisco_bgp$/
+          # cleaning default cleans them all
+          next unless title[/default/]
+        when /^cisco_interface$/
+          next if title[/ethernet/i]
+        when /cisco_snmp_user/
+          next if title[/devops/i]
+        when /cisco_vlan/
+          # TBD: Per-vlan cleanup is too slow. Consider 'no vlan 1-4095'
+          next if title == '1'
+        when /cisco_vrf/
+          next if title[/management/]
+        end
+        logger.info("  * #{stepinfo} Removing #{res_name} '#{title}'")
+        if agent
+          cmd_str = PUPPET_BINPATH + "resource #{res_name} '#{title}' ensure=absent"
+          on(agent, cmd_str, acceptable_exit_codes: [0])
+        else
+          create_and_apply_test_manifest(res_name, title, 'ensure', 'absent')
+        end
       end
     end
   end
-end
 
-# Helper to clean a specific resource by title name
-def resource_absent_by_title(agent, res_name, title)
-  res_cmd = PUPPET_BINPATH + "resource #{res_name}"
-  on(agent, "#{res_cmd} '#{title}' ensure=absent")
-end
-
-# Helper to find all titles of a given resource name.
-# Optionally remove all titles found.
-# Returns an array of titles.
-def resource_titles(agent, res_name, action=:find)
-  res_cmd = PUPPET_BINPATH + "resource #{res_name}"
-  on(agent, res_cmd)
-
-  titles = []
-  stdout.scan(/'.*':/).each { |title| titles << title.gsub(/[':]/, '') }
-  if action == :clean
-    titles.each { |title| resource_absent_by_title(agent, res_name, title) }
+  # Helper to clean a specific resource by title name
+  def resource_absent_by_title(agent, res_name, title)
+    res_cmd = PUPPET_BINPATH + "resource #{res_name}"
+    on(agent, "#{res_cmd} '#{title}' ensure=absent")
   end
-  titles
-end
 
-# Helper to determine if a resource is present
-def resource_present?(agent, name, title)
-  cmd = PUPPET_BINPATH + "resource #{name} #{title}"
-  result = on(agent, cmd).stdout
-  result[/ensure => 'absent'/] ? false : true
-end
+  # Helper to find all titles of a given resource name.
+  # Optionally remove all titles found.
+  # Returns an array of titles.
+  def resource_titles(agent, res_name, action=:find)
+    res_cmd = PUPPET_BINPATH + "resource #{res_name}"
+    on(agent, res_cmd)
 
-# Helper to configure switchport mode
-def config_switchport_mode(agent, intf, mode, stepinfo='switchport mode: ')
-  step "TestStep :: #{stepinfo}" do
-    cmd = "interface #{intf} ; switchport ; switchport mode #{mode}"
-    command_config(agent, cmd, cmd)
-  end
-end
-
-# Helper to toggle 'system default switchport'
-def system_default_switchport(agent, state=false,
-                              stepinfo='system default switchport')
-  step "TestStep :: #{stepinfo} (state: #{state})" do
-    state = state ? ' ' : 'no '
-    cmd = "#{state}system default switchport"
-    command_config(agent, cmd, cmd)
-  end
-end
-
-# Helper for checking/setting 'system default switchport'
-def config_system_default_switchport?(tests, id)
-  return unless tests[id].key?(:sys_def_switchport)
-
-  state = tests[id][:sys_def_switchport]
-  # cached state
-  return if tests[:sys_def_switchport] == state
-
-  system_default_switchport(agent, state)
-  # cache for later tests
-  tests[:sys_def_switchport] = state
-end
-
-# Helper to toggle 'system default switchport shutdown'
-def system_default_switchport_shutdown(agent, state=false,
-                                       stepinfo='system default switchport shutdown')
-  step "TestStep :: #{stepinfo}" do
-    state = state ? ' ' : 'no '
-    cmd = "#{state}system default switchport shutdown"
-    command_config(agent, cmd, cmd)
-  end
-end
-
-# Helper for checking/setting 'system default switchport shutdown'
-def config_system_default_switchport_shutdown?(tests, id)
-  return unless tests[id].key?(:sys_def_sw_shut)
-
-  state = tests[id][:sys_def_sw_shut]
-  # cached state
-  return if tests[:sys_def_sw_shut] == state
-
-  system_default_switchport_shutdown(agent, state)
-  # cache for later tests
-  tests[:sys_def_sw_shut] = state
-end
-
-# Helper for creating / removing an ACL
-def config_acl(agent, afi, acl, state, stepinfo='ACL:')
-  step "TestStep :: #{stepinfo}" do
-    state = state ? 'present' : 'absent'
-    cmd = "resource cisco_acl '#{afi} #{acl}' ensure=#{state}"
-    logger.info("Setup: puppet #{cmd}")
-    cmd = PUPPET_BINPATH + cmd
-    on(agent, cmd, acceptable_exit_codes: [0, 2])
-  end
-end
-
-# Helper for checking/setting ACLs
-def config_acl?(tests, id)
-  tests[id][:acl].each { |acl, afi| config_acl(agent, afi, acl, true) } if
-    tests[id][:acl]
-end
-
-# Helper for creating / removing bridge-domain configs
-# 1. Remove any existing bridge-domain config unless it contains our test_bd
-# 2. Remove vlan with test_bd id
-# 3. Add bridge-domain configs
-def config_bridge_domain(agent, test_bd, stepinfo='bridge-domain config:')
-  step stepinfo do
-    # Find current bridge-domain
-    # NOTE: This should convert to using puppet resource, however, the cli
-    # does not allow changes to bridge-domain without removing existing BD's,
-    # which means we are stuck with vsh for now.
-    cmd = get_vshell_cmd('show run bridge-domain')
-    out = on(agent, cmd).stdout
-    bds = out.scan(/^bridge-domain \d+ /)
-    return if bds.include?("bridge-domain #{test_bd} ")
-
-    bds.each do |bd|
-      command_config(agent, "no #{bd}", "remove #{bd}")
+    titles = []
+    stdout.scan(/'.*':/).each { |title| titles << title.gsub(/[':]/, '') }
+    if action == :clean
+      titles.each { |title| resource_absent_by_title(agent, res_name, title) }
     end
+    titles
+  end
 
-    if (sys_bd = out[/^system bridge-domain .*/])
-      command_config(agent, "no #{sys_bd}", "remove #{sys_bd}")
+  # Helper to determine if a resource is present
+  def resource_present?(agent, name, title)
+    cmd = PUPPET_BINPATH + "resource #{name} #{title}"
+    result = on(agent, cmd).stdout
+    result[/ensure => 'absent'/] ? false : true
+  end
+
+  # Helper to configure switchport mode
+  def config_switchport_mode(agent, intf, mode, stepinfo='switchport mode: ')
+    step "TestStep :: #{stepinfo}" do
+      cmd = "interface #{intf} ; switchport ; switchport mode #{mode}"
+      command_config(agent, cmd, cmd)
     end
-
-    # Remove vlan
-    cmd = "resource cisco_vlan '#{test_bd}' ensure=absent"
-    cmd = PUPPET_BINPATH + cmd
-    on(agent, cmd, acceptable_exit_codes: [0, 2])
-
-    # Configure bridge-domain
-    cmd = "system bridge-domain #{test_bd} ; bridge-domain #{test_bd}"
-    command_config(agent, cmd, cmd)
   end
-end
 
-def config_bridge_domain?(tests, _id)
-  return unless platform[/n7k/] && tests.key?(:bridge_domain)
-
-  bd = tests[:bridge_domain]
-  agent = tests[:agent]
-  on(agent, get_vshell_cmd('show runn bridge-domain'), pty: true)
-
-  config_bridge_domain(agent, bd) unless
-    stdout.match(Regexp.new("^bridge-domain #{bd}"))
-
-  # Delete the key to prevent having to set this for every test case
-  tests.delete(:bridge_domain)
-end
-
-# Helper for creating / removing encap profile vni (global) configs
-def config_encap_profile_vni_global(agent, cmd,
-                                    stepinfo='encap profile vni global:')
-  step stepinfo do
-    command_config(agent, cmd, cmd)
+  # Helper to toggle 'system default switchport'
+  def system_default_switchport(agent, state=false,
+                                stepinfo='system default switchport')
+    step "TestStep :: #{stepinfo} (state: #{state})" do
+      state = state ? ' ' : 'no '
+      cmd = "#{state}system default switchport"
+      command_config(agent, cmd, cmd)
+    end
   end
-end
 
-# Helper to nuke a single interface. This is needed to remove all
-# configurations from the interface.
-def interface_cleanup(agent, intf, stepinfo='Interface Clean:')
-  return if intf.empty?
-  step "TestStep :: #{stepinfo}" do
-    if !agent.nil?
-      cmd = "resource cisco_command_config 'interface_cleanup' "\
-            "command='default interface #{intf}'"
+  # Helper for checking/setting 'system default switchport'
+  def config_system_default_switchport?(tests, id)
+    return unless tests[id].key?(:sys_def_switchport)
+
+    state = tests[id][:sys_def_switchport]
+    # cached state
+    return if tests[:sys_def_switchport] == state
+
+    system_default_switchport(agent, state)
+    # cache for later tests
+    tests[:sys_def_switchport] = state
+  end
+
+  # Helper to toggle 'system default switchport shutdown'
+  def system_default_switchport_shutdown(agent, state=false,
+                                         stepinfo='system default switchport shutdown')
+    step "TestStep :: #{stepinfo}" do
+      state = state ? ' ' : 'no '
+      cmd = "#{state}system default switchport shutdown"
+      command_config(agent, cmd, cmd)
+    end
+  end
+
+  # Helper for checking/setting 'system default switchport shutdown'
+  def config_system_default_switchport_shutdown?(tests, id)
+    return unless tests[id].key?(:sys_def_sw_shut)
+
+    state = tests[id][:sys_def_sw_shut]
+    # cached state
+    return if tests[:sys_def_sw_shut] == state
+
+    system_default_switchport_shutdown(agent, state)
+    # cache for later tests
+    tests[:sys_def_sw_shut] = state
+  end
+
+  # Helper for creating / removing an ACL
+  def config_acl(agent, afi, acl, state, stepinfo='ACL:')
+    step "TestStep :: #{stepinfo}" do
+      state = state ? 'present' : 'absent'
+      cmd = "resource cisco_acl '#{afi} #{acl}' ensure=#{state}"
+      logger.info("Setup: puppet #{cmd}")
       cmd = PUPPET_BINPATH + cmd
-      logger.info("  * #{stepinfo} Set '#{intf}' to default state")
       on(agent, cmd, acceptable_exit_codes: [0, 2])
+    end
+  end
+
+  # Helper for checking/setting ACLs
+  def config_acl?(tests, id)
+    tests[id][:acl].each { |acl, afi| config_acl(agent, afi, acl, true) } if
+      tests[id][:acl]
+  end
+
+  # Helper for creating / removing bridge-domain configs
+  # 1. Remove any existing bridge-domain config unless it contains our test_bd
+  # 2. Remove vlan with test_bd id
+  # 3. Add bridge-domain configs
+  def config_bridge_domain(agent, test_bd, stepinfo='bridge-domain config:')
+    step stepinfo do
+      # Find current bridge-domain
+      # NOTE: This should convert to using puppet resource, however, the cli
+      # does not allow changes to bridge-domain without removing existing BD's,
+      # which means we are stuck with vsh for now.
+      cmd = get_vshell_cmd('show run bridge-domain')
+      out = on(agent, cmd).stdout
+      bds = out.scan(/^bridge-domain \d+ /)
+      return if bds.include?("bridge-domain #{test_bd} ")
+
+      bds.each do |bd|
+        command_config(agent, "no #{bd}", "remove #{bd}")
+      end
+
+      if (sys_bd = out[/^system bridge-domain .*/])
+        command_config(agent, "no #{sys_bd}", "remove #{sys_bd}")
+      end
+
+      # Remove vlan
+      cmd = "resource cisco_vlan '#{test_bd}' ensure=absent"
+      cmd = PUPPET_BINPATH + cmd
+      on(agent, cmd, acceptable_exit_codes: [0, 2])
+
+      # Configure bridge-domain
+      cmd = "system bridge-domain #{test_bd} ; bridge-domain #{test_bd}"
+      command_config(agent, cmd, cmd)
+    end
+  end
+
+  def config_bridge_domain?(tests, _id)
+    return unless platform[/n7k/] && tests.key?(:bridge_domain)
+
+    bd = tests[:bridge_domain]
+    agent = tests[:agent]
+    on(agent, get_vshell_cmd('show runn bridge-domain'), pty: true)
+
+    config_bridge_domain(agent, bd) unless
+      stdout.match(Regexp.new("^bridge-domain #{bd}"))
+
+    # Delete the key to prevent having to set this for every test case
+    tests.delete(:bridge_domain)
+  end
+
+  # Helper for creating / removing encap profile vni (global) configs
+  def config_encap_profile_vni_global(agent, cmd,
+                                      stepinfo='encap profile vni global:')
+    step stepinfo do
+      command_config(agent, cmd, cmd)
+    end
+  end
+
+  # Helper to nuke a single interface. This is needed to remove all
+  # configurations from the interface.
+  def interface_cleanup(agent, intf, stepinfo='Interface Clean:')
+    return if intf.empty?
+    step "TestStep :: #{stepinfo}" do
+      if !agent.nil?
+        cmd = "resource cisco_command_config 'interface_cleanup' "\
+              "command='default interface #{intf}'"
+        cmd = PUPPET_BINPATH + cmd
+        logger.info("  * #{stepinfo} Set '#{intf}' to default state")
+        on(agent, cmd, acceptable_exit_codes: [0, 2])
+      else
+        cmd = "default interface #{intf}"
+        logger.info("  * #{stepinfo} Set '#{intf}' to default state")
+        env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
+        Cisco::Environment.add_env('remote', env)
+        test_client = Cisco::Client.create('remote')
+        test_client.set(values: cmd)
+      end
+    end
+  end
+
+  # Helper to remove all IP address configs from all interfaces. This is
+  # needed to avoid IP conflicts with our test interface.
+  def interface_ip_cleanup(agent, stepinfo='Pre Clean:')
+    logger.debug("#{stepinfo} Interface IP cleanup")
+    show_cmd = get_vshell_cmd('show ip interface brief')
+
+    # Find the interfaces with IP addresses; build a removal config.
+    # Note mgmt0 will not appear in the show cmd output.
+    on(agent, show_cmd)
+    clean = stdout.split("\n").map do |line|
+      "interface #{Regexp.last_match[:intf]} ; no ip addr" if
+        line[/^(?<intf>\S+)\s+\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/]
+    end.compact
+    return if clean.empty?
+    clean = clean.join(' ; ').prepend('conf t ; ')
+    logger.debug("#{stepinfo} Clean string:\n#{clean}")
+    # exit codes: 0 = no changes, 2 = changes have occurred
+    on(agent, get_vshell_cmd(clean), acceptable_exit_codes: [0, 2])
+  end
+
+  # bgp neighbor remote-as configuration helper
+  def bgp_nbr_remote_as(agent, remote_as)
+    asn, vrf, nbr, remote = remote_as.split
+    vrf = (vrf == 'default') ? '' : "vrf #{vrf} ;"
+    cfg_str = "conf t ; router bgp #{asn} ; #{vrf} " \
+              "neighbor #{nbr} ; remote-as #{remote}"
+    on(agent, get_vshell_cmd(cfg_str))
+  end
+
+  # puppet_resource_title_pattern_munge
+  # Some providers support complex title patterns, in which case parameters
+  # ('newparameter' methods from the type file) can obtain their values from
+  # either explicit assignments or from the title pattern itself; e.g.
+  #
+  #  (params from title)                        (non-title params)
+  # cisco_bgp { '55 red':    -equivalent to-   cisco_bgp { '55':
+  #                                              vrf => 'red'
+  #
+  # The 'puppet resource' tests need the "title params" syntax, so this helper
+  # is used to create an appropriate title by merging a partial title from
+  # [:title_pattern] with the [:title_params] values.
+  #
+  def puppet_resource_title_pattern_munge(tests, id) # rubocop:disable Metrics/AbcSize
+    title = tests[id][:title_pattern]
+    params = tests[id][:title_params]
+    return params if title.nil?
+
+    tests[id][:title_params] = {} if params.nil?
+    t = {}
+    case tests[:resource_name]
+    when 'cisco_acl'
+      t[:afi], t[:acl_name] = title.split
+    when 'cisco_bgp'
+      t[:asn], t[:vrf] = title.split
+    when 'cisco_bgp_af'
+      t[:asn], t[:vrf], t[:afi], t[:safi] = title.split
+    when 'cisco_bgp_neighbor'
+      t[:asn], t[:vrf], t[:neighbor] = title.split
+    when 'cisco_bgp_neighbor_af'
+      t[:asn], t[:vrf], t[:neighbor], t[:afi], t[:safi] = title.split
+    when 'cisco_pim'
+      t[:afi], t[:vrf] = title.split
+    when 'cisco_pim_grouplist'
+      t[:afi], t[:vrf], t[:rp_addr], t[:group] = title.split
+    when 'cisco_pim_rp_address'
+      t[:afi], t[:vrf], t[:rp_addr] = title.split
+    when 'cisco_vrf_af'
+      t[:vrf], t[:afi], t[:safi] = title.split
+    end
+    t.merge!(tests[id][:title_params])
+
+    if t[:vrf].nil?
+      case tests[:resource_name]
+      when 'cisco_acl'
+      else
+        t[:vrf] = 'default'
+      end
+    end
+    t
+  end
+
+  # Helper method to create a puppet resource command string for providers
+  # that use complex title patterns (bgp, vrf_af, etc).
+  # [:title_pattern] (required) This string will become the entire cmd string
+  #                  if there are no :title_params
+  # [:title_params] (optional) This hash will be merged with the :title_pattern
+  #                  to create the cmd string
+  def puppet_resource_cmd_from_params(tests, id)
+    fail 'tests[:resource_name] is not defined' unless tests[:resource_name]
+
+    params = tests[id][:title_params]
+    stepinfo = 'Create resource command title string:'\
+               "\n  [:resource_name] '#{tests[:resource_name]}'"\
+               "\n  [:title_pattern] '#{tests[id][:title_pattern]}'"
+    stepinfo += "\n  [:title_params]  #{params}" if params
+
+    step "\n--------\n#{stepinfo}" do
+      # Create puppet resource cmd string. This is used to test
+      # a specific resource instance output using 'puppet resource'
+      if params
+        title_string = puppet_resource_title_pattern_munge(tests, id).values.join(' ')
+      else
+        title_string = tests[id][:title_pattern]
+      end
+
+      cmd = if tests[:agent]
+              PUPPET_BINPATH + "resource #{tests[:resource_name]} '#{title_string}'"
+            else
+              "#{AGENTLESS_COMMAND} --resource #{tests[:resource_name]} '#{title_string}'"
+            end
+
+      logger.info("\ntitle_string: '#{title_string}'")
+      tests[id][:resource_cmd] = cmd
+    end
+  end
+
+  def create_agentless_manifest(tests, resource_name, id, state, manifest, harness_class: BaseHarness)
+    @temp_agentless_manifest = Tempfile.new(TEMP_AGENTLESS_MANIFEST_PREFIX)
+    @temp_agentless_manifest.write("#{harness_class.dependency_manifest(self, tests, id)}
+                                   #{resource_name} { '#{tests[id][:title_pattern]}':
+                               #{state}\n#{manifest}
+                             }\n")
+    @temp_agentless_manifest.rewind
+  end
+
+  # Create manifest and resource command strings for a given test scenario.
+  # Returns true if a valid/non-empty manifest was created, false otherwise.
+  # Test hash keys used by this method:
+  # [:resource_name] (REQUIRED) This is the resource name to use in the manifest
+  #   the for puppet resource command strings
+  # [:manifest_props] (REQUIRED) This is a hash of properties to use in building
+  #   the manifest; they are also used to populate [:resource] when that key is
+  #   not defined.
+  # [:resource] (OPTIONAL) This is a hash of properties to use for validating the
+  #   output from puppet resource.
+  # [:title_pattern] (OPTIONAL) The title pattern to use in the manifest
+  # [:title_params] (OPTIONAL) Complex title patterns can be combined with
+  #   parameter keys in the manifest. When these are used the puppet resource
+  #   command string becomes a combination of the title pattern and these params.
+  #
+  def create_manifest_and_resource(tests, id, harness_class: BaseHarness)
+    fail 'tests[:resource_name] is not defined' unless tests[:resource_name]
+
+    tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
+
+    # Create the cmd string for puppet_resource
+    puppet_resource_cmd_from_params(tests, id)
+
+    # Create any title-params manifest entries. Typically only used
+    # for title-pattern testing
+    manifest = prop_hash_to_manifest(tests[id][:title_params])
+
+    # Setup the ensure state, manifest string, and resource command state
+    state = ''
+    if tests[id][:ensure] == :absent
+      state = 'ensure => absent,'
+      tests[id][:resource] = { 'ensure' => 'absent' }
     else
-      cmd = "default interface #{intf}"
-      logger.info("  * #{stepinfo} Set '#{intf}' to default state")
+      state = 'ensure => present,' unless tests[:ensurable] == false
+
+      tests[id][:resource]['ensure'] = nil unless
+          tests[id][:resource].nil? || tests[:ensurable] == false
+
+      manifest_props = tests[id][:manifest_props]
+      if manifest_props
+        manifest_props = supported_property_hash(tests, id, manifest_props, harness_class: harness_class)
+
+        # we shouldn't continue if all properties were removed
+        return false if
+          manifest_props.empty? && !tests[id][:manifest_props].empty?
+
+        # Create the property string for the manifest
+        manifest += prop_hash_to_manifest(manifest_props) if manifest_props
+      end
+
+      # Automatically create a hash of expected states for puppet resource
+      # -or- use a static hash
+      # TBD: Need a prop_hash_to_resource to handle array patterns
+      tests[id][:resource] = manifest_props unless tests[id][:resource]
+    end
+
+    tests[id][:manifest] = if tests[:agent]
+                             "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+                           \nnode default {
+                           #{harness_class.dependency_manifest(self, tests, id)}
+                           #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
+                             #{state}\n#{manifest}
+                           }\n}\nEOF"
+                           else
+                             create_agentless_manifest(tests, tests[:resource_name], id, state, manifest, harness_class: harness_class)
+                           end
+    true
+  end
+
+  # Special create manifest/resource method for yum packages only.
+  def create_package_manifest_resource(tests, id, harness_class: BaseHarness)
+    puppet_resource_cmd_from_params(tests, id)
+    state = ''
+    manifest = ''
+    if tests[id][:ensure] == :absent
+      state = 'ensure => absent,'
+    else
+      state = 'ensure => present,'
+    end
+
+    manifest_props = tests[id][:manifest_props]
+    manifest += prop_hash_to_manifest(manifest_props)
+    tests[id][:resource] = manifest_props
+    tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+    \nnode default {
+    #{harness_class.dependency_manifest(self, tests, id)}
+    #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
+      #{state}\n#{manifest}
+    }\n}\nEOF"
+
+    true
+  end
+
+  # supported_property_hash
+  #
+  # This method creates a clone of the specified property
+  # hash containing only the key/values of properties
+  # that are supported for the specified test (based on
+  # operating_system, platform, etc.).
+  def supported_property_hash(tests, id, property_hash, harness_class: BaseHarness)
+    return nil if property_hash.nil?
+    copy = property_hash.clone
+    harness_class.unsupported_properties(self, tests, id).each do |prop_symbol|
+      next unless prop_symbol
+      copy.delete(prop_symbol)
+      # because :resource hash currently uses strings for keys
+      copy.delete(prop_symbol.to_s)
+    end
+
+    lim = full_version.split[0].tr('(', '.').tr(')', '.').chomp('.')
+    # due to a bug in Gem::Version, we need to append a letter
+    # to the version field if the to be compared version
+    # has a letter at the end
+    # For ex:
+    # 7.0.3.I2.2e < 7.0.3.I2.2 is TRUE instead of FALSE
+    # Once we add a letter 'a' to the end,
+    # 7.0.3.I2.2e < 7.0.3.I2.2a is FALSE
+    append_a = false
+    append_a = true if lim[-1, 1] =~ /[[:alpha:]]/
+    harness_class.version_unsupported_properties(self, tests, id).each do |key, val|
+      next unless key
+      val << 'a' if append_a
+      append_a = false
+      next unless Gem::Version.new(lim) < Gem::Version.new(val)
+      copy.delete(key)
+      # because :resource hash currently uses strings for keys
+      copy.delete(key.to_s)
+    end
+    copy
+  end
+
+  # test_harness_run
+  #
+  # This method is a front-end for test_harness_common.
+  # - Creates manifests
+  # - Creates puppet resource title strings
+  # - Cleans resource
+  def test_harness_run(tests, id, harness_class: BaseHarness, skip_idempotence_check: false)
+    return unless platform_supports_test(tests, id)
+    logger.info("\n  * Process test_harness_run")
+    tests[id][:ensure] = :present if tests[id][:ensure].nil?
+
+    # Build the manifest for this test
+    unless create_manifest_and_resource(tests, id, harness_class: harness_class)
+      logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
+      logger.error('No supported properties remain for this test.')
+      return
+    end
+
+    resource_absent_cleanup(agent, tests[id][:preclean]) if
+      tests[id][:preclean]
+
+    # Check for additional pre-requisites
+    harness_class.test_harness_dependencies(self, tests, id)
+
+    test_harness_common(tests, id, harness_class: harness_class, skip_idempotence_check: skip_idempotence_check)
+    tests[id][:ensure] = nil
+  end
+
+  # setup_mt_full_env
+  # Check and set up prerequisites for Multi-Tenancy Full (MT-full) testing.
+  # MT-full currently requires an F3 line module. This method will update
+  # the tests hash with the names of the default vdc and also an appropriate
+  # test interface name to use for testing.
+  # tests[:vdc] The default vdc name
+  # tests[:intf] A compatible interface to use for MT-full testing.
+  # rubocop:disable Metrics/AbcSize
+  def setup_mt_full_env(tests, testcase)
+    # MT-full tests require a specific linecard. Search for a compatible
+    # module and enable it.
+
+    logger.info('Process setup_mt_full_env')
+    testheader = tests[:resource_name]
+    mod = tests[:vdc_limit_module]
+    mod = 'f3' if mod.nil?
+
+    step 'Check for Compatible Line Module' do
+      tests[:intf] = mt_full_interface
+      break if tests[:intf]
+      prereq_skip(testheader, testcase,
+                  "MT-full tests require #{mod} or compatible line module")
+    end if tests[:intf].nil?
+    intf = tests[:intf]
+    logger.info("Test interface name is '#{intf}'")
+
+    step 'Get default VDC name' do
+      tests[:vdc] = default_vdc_name
+      break if tests[:vdc]
+      prereq_skip(testheader, testcase, 'Unable to determine default vdc name')
+    end if tests[:vdc].nil?
+    vdc = tests[:vdc]
+
+    step "Check for 'limit-resource module-type #{mod}'" do
+      break if limit_resource_module_type_get(vdc, mod, :exact)
+      limit_resource_module_type_set(vdc, mod)
+      break if limit_resource_module_type_get(vdc, mod)
+      prereq_skip(testheader, testcase,
+                  "Unable to set limit-resource module-type to '#{mod}'")
+    end
+
+    step "Verify that '#{intf}' is allocated to VDC" do
+      break if vdc_allocate_interface_get(vdc, intf)
+      logger.info("'#{intf}' is not allocated to VDC, allocate it now...")
+      vdc_allocate_interface_set(vdc, intf)
+      break if vdc_allocate_interface_get(vdc, intf)
+      prereq_skip(testheader, testcase,
+                  "Unable to allocate interface '#{intf}' to VDC")
+    end
+
+    interface_cleanup(agent, intf)
+
+    config_switchport_mode(agent, intf, tests[:switchport_mode]) if
+      tests[:switchport_mode]
+
+    config_bridge_domain(agent, tests[:bridge_domain]) if
+      tests[:bridge_domain]
+
+    config_encap_profile_vni_global(agent, tests[:encap_prof_global]) if
+      tests[:encap_prof_global]
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # setup_fabricpath_env
+  # Check and set up prerequisites for fabricpath testing.
+  # Fabricpath requires an F series line module. This method will update
+  # the tests hash with the names of the default vdc and also an appropriate
+  # test interface name to use for testing.
+  # tests[:vdc] The default vdc name
+  # tests[:intf] A compatible interface to use for Fabricpath testing.
+  def setup_fabricpath_env(tests, testcase)
+    # Fabricpath tests require a specific linecard. Search for a compatible
+    # module and enable it.
+
+    return unless platform == 'n7k'
+
+    testheader = tests[:resource_name]
+    mod = tests[:vdc_limit_module]
+    mod = 'f2e f3' if mod.nil?
+
+    step 'Check for Compatible Line Module' do
+      tests[:intf_type] = 'ethernet'
+      tests[:intf] = fabricpath_interface
+      break if tests[:intf]
+      prereq_skip(testheader, testcase,
+                  "Fabricpath tests require #{mod} or compatible line module")
+    end if tests[:intf].nil?
+    intf = tests[:intf]
+    logger.info("Test interface name is '#{intf}'")
+
+    step 'Get default VDC name' do
+      tests[:vdc] = default_vdc_name
+      break if tests[:vdc]
+      prereq_skip(testheader, testcase, 'Unable to determine default vdc name')
+    end if tests[:vdc].nil?
+    vdc = tests[:vdc]
+
+    step "Set 'limit-resource module-type #{mod}'" do
+      limit_resource_module_type_set(vdc, mod)
+      break if limit_resource_module_type_get(vdc, mod)
+      prereq_skip(testheader, testcase,
+                  "Unable to set limit-resource module-type to '#{mod}'")
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # Given a configuration command (or array of commands), search the device
+  # and remove any configs that match. Optionally include a show command filter.
+  #
+  # Example:
+  #  config_find_remove(agent, 'interface loopback42')
+  #  config_find_remove(agent, ['interface loopback42', 'feature foo'])
+  #  config_find_remove(agent, ['feature foo', 'feature bar'], 'incl ^feature')
+  #
+  def config_find_remove(agent, find=[], filter='incl .*')
+    find = [find] if find.is_a?(String)
+    remove = []
+    current = test_get(agent, filter)
+
+    find.each do |cfg|
+      remove << "no #{cfg}" if current.match(Regexp.new("^#{cfg}"))
+    end
+    return if remove.empty?
+
+    # Clean up all configs with one call
+    logger.info(' * Remove existing config')
+    test_set(agent, remove.join(' ; '))
+  end
+
+  # Get raw configuration from the device using command_config's test_get.
+  # test_get does a 'show runn' but requires a filter.
+  # Example:
+  #  test_get(agent, 'incl ^vlan')
+  #
+  # opt = :raw, return raw output from puppet resource command
+  # opt = :array, return array of test_get property data only
+  def test_get(agent, filter, opt=:raw)
+    if !agent.nil?
+      cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
+      on(agent, cmd_prefix + "test_get=\"#{filter}\"")
+      command = stdout
+    else
+      env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
+      Cisco::Environment.add_env('remote', env)
+      test_client = Cisco::Client.create('remote')
+      command = test_client.get(data_fomat: :cli, command: "show running-config all | #{filter}")
+    end
+    case opt
+    when :raw
+      return command
+    when :array
+      # clean up the output and return as array of commands
+      # stdout: " cisco_command_config { 'cc':\n  test_get => '\n foo\n bar\n',\n}"
+      # array:  [' foo', ' bar']
+      command.split("\n")[2..-3] if command
+    end
+  end
+
+  # Add arbitrary configurations using command_config's test_set property.
+  # Example:
+  #  test_set(agent, 'no feature foo ; no feature bar')
+  def test_set(agent, cmd)
+    return if cmd.empty?
+    logger.info(cmd)
+    if !agent.nil?
+      cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
+      on(agent, cmd_prefix + "test_set='#{cmd}'")
+    else
       env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
       Cisco::Environment.add_env('remote', env)
       test_client = Cisco::Client.create('remote')
       test_client.set(values: cmd)
     end
   end
-end
 
-# Helper to remove all IP address configs from all interfaces. This is
-# needed to avoid IP conflicts with our test interface.
-def interface_ip_cleanup(agent, stepinfo='Pre Clean:')
-  logger.debug("#{stepinfo} Interface IP cleanup")
-  show_cmd = get_vshell_cmd('show ip interface brief')
-
-  # Find the interfaces with IP addresses; build a removal config.
-  # Note mgmt0 will not appear in the show cmd output.
-  on(agent, show_cmd)
-  clean = stdout.split("\n").map do |line|
-    "interface #{Regexp.last_match[:intf]} ; no ip addr" if
-      line[/^(?<intf>\S+)\s+\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/]
-  end.compact
-  return if clean.empty?
-  clean = clean.join(' ; ').prepend('conf t ; ')
-  logger.debug("#{stepinfo} Clean string:\n#{clean}")
-  # exit codes: 0 = no changes, 2 = changes have occurred
-  on(agent, get_vshell_cmd(clean), acceptable_exit_codes: [0, 2])
-end
-
-# bgp neighbor remote-as configuration helper
-def bgp_nbr_remote_as(agent, remote_as)
-  asn, vrf, nbr, remote = remote_as.split
-  vrf = (vrf == 'default') ? '' : "vrf #{vrf} ;"
-  cfg_str = "conf t ; router bgp #{asn} ; #{vrf} " \
-            "neighbor #{nbr} ; remote-as #{remote}"
-  on(agent, get_vshell_cmd(cfg_str))
-end
-
-# puppet_resource_title_pattern_munge
-# Some providers support complex title patterns, in which case parameters
-# ('newparameter' methods from the type file) can obtain their values from
-# either explicit assignments or from the title pattern itself; e.g.
-#
-#  (params from title)                        (non-title params)
-# cisco_bgp { '55 red':    -equivalent to-   cisco_bgp { '55':
-#                                              vrf => 'red'
-#
-# The 'puppet resource' tests need the "title params" syntax, so this helper
-# is used to create an appropriate title by merging a partial title from
-# [:title_pattern] with the [:title_params] values.
-#
-def puppet_resource_title_pattern_munge(tests, id) # rubocop:disable Metrics/AbcSize
-  title = tests[id][:title_pattern]
-  params = tests[id][:title_params]
-  return params if title.nil?
-
-  tests[id][:title_params] = {} if params.nil?
-  t = {}
-  case tests[:resource_name]
-  when 'cisco_acl'
-    t[:afi], t[:acl_name] = title.split
-  when 'cisco_bgp'
-    t[:asn], t[:vrf] = title.split
-  when 'cisco_bgp_af'
-    t[:asn], t[:vrf], t[:afi], t[:safi] = title.split
-  when 'cisco_bgp_neighbor'
-    t[:asn], t[:vrf], t[:neighbor] = title.split
-  when 'cisco_bgp_neighbor_af'
-    t[:asn], t[:vrf], t[:neighbor], t[:afi], t[:safi] = title.split
-  when 'cisco_pim'
-    t[:afi], t[:vrf] = title.split
-  when 'cisco_pim_grouplist'
-    t[:afi], t[:vrf], t[:rp_addr], t[:group] = title.split
-  when 'cisco_pim_rp_address'
-    t[:afi], t[:vrf], t[:rp_addr] = title.split
-  when 'cisco_vrf_af'
-    t[:vrf], t[:afi], t[:safi] = title.split
-  end
-  t.merge!(tests[id][:title_params])
-
-  if t[:vrf].nil?
-    case tests[:resource_name]
-    when 'cisco_acl'
+  # Helper for command_config calls
+  def command_config(agent, cmd, msg='')
+    logger.info("\n#{msg}")
+    if !agent.nil?
+      cmd = "resource cisco_command_config 'cc' command='#{cmd}'"
+      cmd = PUPPET_BINPATH + cmd
+      on(agent, cmd, acceptable_exit_codes: [0, 2])
     else
-      t[:vrf] = 'default'
+      env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
+      Cisco::Environment.add_env('remote', env)
+      test_client = Cisco::Client.create('remote')
+      test_client.set(values: cmd)
     end
   end
-  t
-end
 
-# Helper method to create a puppet resource command string for providers
-# that use complex title patterns (bgp, vrf_af, etc).
-# [:title_pattern] (required) This string will become the entire cmd string
-#                  if there are no :title_params
-# [:title_params] (optional) This hash will be merged with the :title_pattern
-#                  to create the cmd string
-def puppet_resource_cmd_from_params(tests, id)
-  fail 'tests[:resource_name] is not defined' unless tests[:resource_name]
-
-  params = tests[id][:title_params]
-  stepinfo = 'Create resource command title string:'\
-             "\n  [:resource_name] '#{tests[:resource_name]}'"\
-             "\n  [:title_pattern] '#{tests[id][:title_pattern]}'"
-  stepinfo += "\n  [:title_params]  #{params}" if params
-
-  step "\n--------\n#{stepinfo}" do
-    # Create puppet resource cmd string. This is used to test
-    # a specific resource instance output using 'puppet resource'
-    if params
-      title_string = puppet_resource_title_pattern_munge(tests, id).values.join(' ')
+  # Helper to set properties using the puppet resource command.
+  def resource_set(agent, resource, msg='')
+    logger.info("\nresource_set: #{msg}")
+    if resource.is_a?(Array)
+      cmd =
+        "resource %s '%s' %s='%s'" % resource # rubocop:disable Style/FormatString
     else
-      title_string = tests[id][:title_pattern]
+      cmd = "resource #{resource[:name]} '#{resource[:title]}' "\
+            "#{resource[:property]}='#{resource[:value]}'"
     end
-
-    cmd = if tests[:agent]
-            PUPPET_BINPATH + "resource #{tests[:resource_name]} '#{title_string}'"
-          else
-            "#{AGENTLESS_COMMAND} --resource #{tests[:resource_name]} '#{title_string}'"
-          end
-
-    logger.info("\ntitle_string: '#{title_string}'")
-    tests[id][:resource_cmd] = cmd
-  end
-end
-
-def create_agentless_manifest(tests, resource_name, id, state, manifest)
-  @temp_agentless_manifest = Tempfile.new(TEMP_AGENTLESS_MANIFEST_PREFIX)
-  @temp_agentless_manifest.write("#{dependency_manifest(tests, id)}
-                                 #{resource_name} { '#{tests[id][:title_pattern]}':
-                             #{state}\n#{manifest}
-                           }\n")
-  @temp_agentless_manifest.rewind
-end
-
-# Create manifest and resource command strings for a given test scenario.
-# Returns true if a valid/non-empty manifest was created, false otherwise.
-# Test hash keys used by this method:
-# [:resource_name] (REQUIRED) This is the resource name to use in the manifest
-#   the for puppet resource command strings
-# [:manifest_props] (REQUIRED) This is a hash of properties to use in building
-#   the manifest; they are also used to populate [:resource] when that key is
-#   not defined.
-# [:resource] (OPTIONAL) This is a hash of properties to use for validating the
-#   output from puppet resource.
-# [:title_pattern] (OPTIONAL) The title pattern to use in the manifest
-# [:title_params] (OPTIONAL) Complex title patterns can be combined with
-#   parameter keys in the manifest. When these are used the puppet resource
-#   command string becomes a combination of the title pattern and these params.
-#
-def create_manifest_and_resource(tests, id, harness_class: nil)
-  fail 'tests[:resource_name] is not defined' unless tests[:resource_name]
-
-  tests[id][:title_pattern] = id if tests[id][:title_pattern].nil?
-
-  # Create the cmd string for puppet_resource
-  puppet_resource_cmd_from_params(tests, id)
-
-  # Create any title-params manifest entries. Typically only used
-  # for title-pattern testing
-  manifest = prop_hash_to_manifest(tests[id][:title_params])
-
-  # Setup the ensure state, manifest string, and resource command state
-  state = ''
-  if tests[id][:ensure] == :absent
-    state = 'ensure => absent,'
-    tests[id][:resource] = { 'ensure' => 'absent' }
-  else
-    state = 'ensure => present,' unless tests[:ensurable] == false
-
-    tests[id][:resource]['ensure'] = nil unless
-        tests[id][:resource].nil? || tests[:ensurable] == false
-
-    manifest_props = tests[id][:manifest_props]
-    if manifest_props
-      manifest_props = supported_property_hash(tests, id, manifest_props, harness_class: harness_class)
-
-      # we shouldn't continue if all properties were removed
-      return false if
-        manifest_props.empty? && !tests[id][:manifest_props].empty?
-
-      # Create the property string for the manifest
-      manifest += prop_hash_to_manifest(manifest_props) if manifest_props
-    end
-
-    # Automatically create a hash of expected states for puppet resource
-    # -or- use a static hash
-    # TBD: Need a prop_hash_to_resource to handle array patterns
-    tests[id][:resource] = manifest_props unless tests[id][:resource]
-  end
-
-  tests[id][:manifest] = if tests[:agent]
-                           "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-                         \nnode default {
-                         #{dependency_manifest(tests, id)}
-                         #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
-                           #{state}\n#{manifest}
-                         }\n}\nEOF"
-                         else
-                           create_agentless_manifest(tests, tests[:resource_name], id, state, manifest)
-                         end
-  true
-end
-
-# Special create manifest/resource method for yum packages only.
-def create_package_manifest_resource(tests, id)
-  puppet_resource_cmd_from_params(tests, id)
-  state = ''
-  manifest = ''
-  if tests[id][:ensure] == :absent
-    state = 'ensure => absent,'
-  else
-    state = 'ensure => present,'
-  end
-
-  manifest_props = tests[id][:manifest_props]
-  manifest += prop_hash_to_manifest(manifest_props)
-  tests[id][:resource] = manifest_props
-  tests[id][:manifest] = "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
-  \nnode default {
-  #{dependency_manifest(tests, id)}
-  #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
-    #{state}\n#{manifest}
-  }\n}\nEOF"
-
-  true
-end
-
-# dependency_manifest
-#
-# This method returns a string representation of a manifest that contains
-# any dependencies needed for a particular test to run.
-# Override this in a particular test file as needed.
-def dependency_manifest(_tests, _id)
-  nil # indicates no manifest dependencies
-end
-
-# supported_property_hash
-#
-# This method creates a clone of the specified property
-# hash containing only the key/values of properties
-# that are supported for the specified test (based on
-# operating_system, platform, etc.).
-def supported_property_hash(tests, id, property_hash, harness_class: nil)
-  return nil if property_hash.nil?
-  copy = property_hash.clone
-  harness_class.unsupported_properties(tests, id).each do |prop_symbol|
-    copy.delete(prop_symbol)
-    # because :resource hash currently uses strings for keys
-    copy.delete(prop_symbol.to_s)
-  end if harness_class && harness_class.respond_to?(:unsupported_properties)
-  return copy unless harness_class && harness_class.respond_to?(:version_unsupported_properties)
-  lim = full_version.split[0].tr('(', '.').tr(')', '.').chomp('.')
-  # due to a bug in Gem::Version, we need to append a letter
-  # to the version field if the to be compared version
-  # has a letter at the end
-  # For ex:
-  # 7.0.3.I2.2e < 7.0.3.I2.2 is TRUE instead of FALSE
-  # Once we add a letter 'a' to the end,
-  # 7.0.3.I2.2e < 7.0.3.I2.2a is FALSE
-  append_a = false
-  append_a = true if lim[-1, 1] =~ /[[:alpha:]]/
-  harness_class.version_unsupported_properties(tests, id).each do |key, val|
-    val << 'a' if append_a
-    append_a = false
-    next unless Gem::Version.new(lim) < Gem::Version.new(val)
-    copy.delete(key)
-    # because :resource hash currently uses strings for keys
-    copy.delete(key.to_s)
-  end if harness_class.respond_to?(:version_unsupported_properties)
-  copy
-end
-
-# test_harness_run
-#
-# This method is a front-end for test_harness_common.
-# - Creates manifests
-# - Creates puppet resource title strings
-# - Cleans resource
-def test_harness_run(tests, id, harness_class: nil, skip_idempotence_check: false)
-  return unless platform_supports_test(tests, id)
-  logger.info("\n  * Process test_harness_run")
-  tests[id][:ensure] = :present if tests[id][:ensure].nil?
-
-  # Build the manifest for this test
-  unless create_manifest_and_resource(tests, id, harness_class: harness_class)
-    logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
-    logger.error('No supported properties remain for this test.')
-    return
-  end
-
-  resource_absent_cleanup(agent, tests[id][:preclean]) if
-    tests[id][:preclean]
-
-  # Check for additional pre-requisites
-  harness_class.test_harness_dependencies(tests, id) if harness_class && harness_class.respond_to?(:test_harness_dependencies)
-
-  test_harness_common(tests, id, harness_class: harness_class, skip_idempotence_check: skip_idempotence_check)
-  tests[id][:ensure] = nil
-end
-
-# setup_mt_full_env
-# Check and set up prerequisites for Multi-Tenancy Full (MT-full) testing.
-# MT-full currently requires an F3 line module. This method will update
-# the tests hash with the names of the default vdc and also an appropriate
-# test interface name to use for testing.
-# tests[:vdc] The default vdc name
-# tests[:intf] A compatible interface to use for MT-full testing.
-# rubocop:disable Metrics/AbcSize
-def setup_mt_full_env(tests, testcase)
-  # MT-full tests require a specific linecard. Search for a compatible
-  # module and enable it.
-
-  logger.info('Process setup_mt_full_env')
-  testheader = tests[:resource_name]
-  mod = tests[:vdc_limit_module]
-  mod = 'f3' if mod.nil?
-
-  step 'Check for Compatible Line Module' do
-    tests[:intf] = mt_full_interface
-    break if tests[:intf]
-    prereq_skip(testheader, testcase,
-                "MT-full tests require #{mod} or compatible line module")
-  end if tests[:intf].nil?
-  intf = tests[:intf]
-  logger.info("Test interface name is '#{intf}'")
-
-  step 'Get default VDC name' do
-    tests[:vdc] = default_vdc_name
-    break if tests[:vdc]
-    prereq_skip(testheader, testcase, 'Unable to determine default vdc name')
-  end if tests[:vdc].nil?
-  vdc = tests[:vdc]
-
-  step "Check for 'limit-resource module-type #{mod}'" do
-    break if limit_resource_module_type_get(vdc, mod, :exact)
-    limit_resource_module_type_set(vdc, mod)
-    break if limit_resource_module_type_get(vdc, mod)
-    prereq_skip(testheader, testcase,
-                "Unable to set limit-resource module-type to '#{mod}'")
-  end
-
-  step "Verify that '#{intf}' is allocated to VDC" do
-    break if vdc_allocate_interface_get(vdc, intf)
-    logger.info("'#{intf}' is not allocated to VDC, allocate it now...")
-    vdc_allocate_interface_set(vdc, intf)
-    break if vdc_allocate_interface_get(vdc, intf)
-    prereq_skip(testheader, testcase,
-                "Unable to allocate interface '#{intf}' to VDC")
-  end
-
-  interface_cleanup(agent, intf)
-
-  config_switchport_mode(agent, intf, tests[:switchport_mode]) if
-    tests[:switchport_mode]
-
-  config_bridge_domain(agent, tests[:bridge_domain]) if
-    tests[:bridge_domain]
-
-  config_encap_profile_vni_global(agent, tests[:encap_prof_global]) if
-    tests[:encap_prof_global]
-end
-# rubocop:enable Metrics/AbcSize
-
-# setup_fabricpath_env
-# Check and set up prerequisites for fabricpath testing.
-# Fabricpath requires an F series line module. This method will update
-# the tests hash with the names of the default vdc and also an appropriate
-# test interface name to use for testing.
-# tests[:vdc] The default vdc name
-# tests[:intf] A compatible interface to use for Fabricpath testing.
-def setup_fabricpath_env(tests, testcase)
-  # Fabricpath tests require a specific linecard. Search for a compatible
-  # module and enable it.
-
-  return unless platform == 'n7k'
-
-  testheader = tests[:resource_name]
-  mod = tests[:vdc_limit_module]
-  mod = 'f2e f3' if mod.nil?
-
-  step 'Check for Compatible Line Module' do
-    tests[:intf_type] = 'ethernet'
-    tests[:intf] = fabricpath_interface
-    break if tests[:intf]
-    prereq_skip(testheader, testcase,
-                "Fabricpath tests require #{mod} or compatible line module")
-  end if tests[:intf].nil?
-  intf = tests[:intf]
-  logger.info("Test interface name is '#{intf}'")
-
-  step 'Get default VDC name' do
-    tests[:vdc] = default_vdc_name
-    break if tests[:vdc]
-    prereq_skip(testheader, testcase, 'Unable to determine default vdc name')
-  end if tests[:vdc].nil?
-  vdc = tests[:vdc]
-
-  step "Set 'limit-resource module-type #{mod}'" do
-    limit_resource_module_type_set(vdc, mod)
-    break if limit_resource_module_type_get(vdc, mod)
-    prereq_skip(testheader, testcase,
-                "Unable to set limit-resource module-type to '#{mod}'")
-  end
-end
-# rubocop:enable Metrics/AbcSize
-
-# Given a configuration command (or array of commands), search the device
-# and remove any configs that match. Optionally include a show command filter.
-#
-# Example:
-#  config_find_remove(agent, 'interface loopback42')
-#  config_find_remove(agent, ['interface loopback42', 'feature foo'])
-#  config_find_remove(agent, ['feature foo', 'feature bar'], 'incl ^feature')
-#
-def config_find_remove(agent, find=[], filter='incl .*')
-  find = [find] if find.is_a?(String)
-  remove = []
-  current = test_get(agent, filter)
-
-  find.each do |cfg|
-    remove << "no #{cfg}" if current.match(Regexp.new("^#{cfg}"))
-  end
-  return if remove.empty?
-
-  # Clean up all configs with one call
-  logger.info(' * Remove existing config')
-  test_set(agent, remove.join(' ; '))
-end
-
-# Get raw configuration from the device using command_config's test_get.
-# test_get does a 'show runn' but requires a filter.
-# Example:
-#  test_get(agent, 'incl ^vlan')
-#
-# opt = :raw, return raw output from puppet resource command
-# opt = :array, return array of test_get property data only
-def test_get(agent, filter, opt=:raw)
-  if !agent.nil?
-    cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
-    on(agent, cmd_prefix + "test_get=\"#{filter}\"")
-    command = stdout
-  else
-    env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
-    Cisco::Environment.add_env('remote', env)
-    test_client = Cisco::Client.create('remote')
-    command = test_client.get(data_fomat: :cli, command: "show running-config all | #{filter}")
-  end
-  case opt
-  when :raw
-    return command
-  when :array
-    # clean up the output and return as array of commands
-    # stdout: " cisco_command_config { 'cc':\n  test_get => '\n foo\n bar\n',\n}"
-    # array:  [' foo', ' bar']
-    command.split("\n")[2..-3] if command
-  end
-end
-
-# Add arbitrary configurations using command_config's test_set property.
-# Example:
-#  test_set(agent, 'no feature foo ; no feature bar')
-def test_set(agent, cmd)
-  return if cmd.empty?
-  logger.info(cmd)
-  if !agent.nil?
-    cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
-    on(agent, cmd_prefix + "test_set='#{cmd}'")
-  else
-    env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
-    Cisco::Environment.add_env('remote', env)
-    test_client = Cisco::Client.create('remote')
-    test_client.set(values: cmd)
-  end
-end
-
-# Helper for command_config calls
-def command_config(agent, cmd, msg='')
-  logger.info("\n#{msg}")
-  if !agent.nil?
-    cmd = "resource cisco_command_config 'cc' command='#{cmd}'"
     cmd = PUPPET_BINPATH + cmd
     on(agent, cmd, acceptable_exit_codes: [0, 2])
-  else
-    env = { host: @nexus_host[:vmhostname], port: 22, username: @nexus_host[:ssh][:user], password: @nexus_host[:ssh][:password], cookie: nil }
-    Cisco::Environment.add_env('remote', env)
-    test_client = Cisco::Client.create('remote')
-    test_client.set(values: cmd)
-  end
-end
-
-# Helper to set properties using the puppet resource command.
-def resource_set(agent, resource, msg='')
-  logger.info("\nresource_set: #{msg}")
-  if resource.is_a?(Array)
-    cmd =
-      "resource %s '%s' %s='%s'" % resource # rubocop:disable Style/FormatString
-  else
-    cmd = "resource #{resource[:name]} '#{resource[:title]}' "\
-          "#{resource[:property]}='#{resource[:value]}'"
-  end
-  cmd = PUPPET_BINPATH + cmd
-  on(agent, cmd, acceptable_exit_codes: [0, 2])
-end
-
-# Helper to raise skip when prereqs are not met
-def prereq_skip(testheader, testcase, message)
-  testheader = '' if testheader.nil?
-  logger.error("** PLATFORM PREREQUISITE NOT MET: #{message}")
-  raise_skip_exception(testheader, testcase)
-end
-
-# Some specific platform models do not support nv_overlay
-def skip_if_nv_overlay_rejected(agent)
-  logger.info('Check for nv overlay support')
-  cmd = get_vshell_cmd('config t ; feature nv overlay')
-  on(agent, cmd, pty: true)
-  # Failure message taken from 6001
-  msg = 'NVE Feature NOT supported on this Platform'
-  banner = '#' * msg.length
-  raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self) if
-    stdout.match(msg)
-end
-
-# Return an interface name from the first MT-full compatible line module found
-def mt_full_interface
-  # Search for F3 card on device, create an interface name if found
-  cmd = get_vshell_cmd('sh mod')
-  out = on(agent, cmd, pty: true).stdout[/^(\d+)\s.*N7[K7]-F3/]
-  slot = out.nil? ? nil : Regexp.last_match[1]
-  "ethernet#{slot}/1" unless slot.nil?
-end
-
-# Return an interface name from the first Fabricpath compatible line module
-# found
-def fabricpath_interface
-  # Search for F2E/F3 cards on device, create an interface name if found
-  cmd = '-p cisco.feature_compatible_module_iflist.fabricpath'
-  if_array_str = on(agent, facter_cmd(cmd)).stdout.chomp
-  if_array_str.gsub!(/[\[\]\n\s"]/, '')
-  if_array = if_array_str.split(',')
-  if_array[0] unless if_array.empty?
-end
-
-# Return the default vdc name
-def default_vdc_name
-  cmd = get_vshell_cmd('sh run vdc')
-  out = on(agent, cmd, pty: true).stdout[/^vdc (\S+) id 1$/]
-  out.nil? ? nil : Regexp.last_match[1]
-end
-
-# Check for presence of limit-resource module-type
-# The lookup is a loose match by default but some features like 'vni' are
-# required to use a specific set of modules only, in which case specify
-# ':exact' for a strict match of the current modules.
-def limit_resource_module_type_get(vdc, mod, match=nil)
-  cmd = get_vshell_cmd("sh vdc #{vdc} detail")
-  if match == :exact
-    # Must be this list of modules only
-    pat = Regexp.new("vdc supported linecards: (#{mod})")
-  else
-    # Just make sure module type is in list
-    pat = Regexp.new("vdc supported linecards:.*(#{mod})")
-  end
-  out = on(agent, cmd, pty: true).stdout.match(pat)
-  out.nil? ? nil : Regexp.last_match[1]
-end
-
-# Set limit-resource module-type
-def limit_resource_module_type_set(vdc, mod, default=false)
-  mod = 'default' if default || mod.nil?
-  resource_vdc_mod = {
-    name:     'cisco_vdc',
-    title:    vdc,
-    property: 'limit_resource_module_type',
-    value:    mod,
-  }
-  resource_set(agent, resource_vdc_mod, "Enable module-type #{mod}")
-end
-
-# Check for presence of interface in vdc allocated interfaces
-def vdc_allocate_interface_get(vdc, intf)
-  intf_pat = "(#{intf}) " # note trailing space
-  cmd = get_vshell_cmd("sh vdc #{vdc} membership")
-  out = on(agent, cmd, pty: true).stdout.match(
-    Regexp.new(intf_pat, Regexp::IGNORECASE))
-  out.nil? ? nil : Regexp.last_match[1]
-end
-
-# Add interface to vdc's allocated interfaces
-def vdc_allocate_interface_set(vdc, intf)
-  # Turn off prompting
-  cmd = get_vshell_cmd('terminal dont-ask persist')
-  on(agent, cmd, pty: true)
-
-  cmd = get_vshell_cmd("conf t ; vdc #{vdc} ; "\
-                       "allocate interface #{intf}")
-  on(agent, cmd, pty: true)
-
-  # Reset prompting to default state
-  cmd = get_vshell_cmd('no terminal dont-ask persist')
-  on(agent, cmd, pty: true)
-end
-
-# VDC post-test cleanup
-def teardown_vdc
-  return if mt_full_interface
-
-  # Testbeds without F3 cards should be set back to their default state;
-  # failure to do so will leave the testbed without usable interfaces.
-  # Assume that F3 testbeds should be left with module-type set to F3.
-  logger.info("\n* Teardown VDC: Reset limit-resource module-type")
-  limit_resource_module_type_set(default_vdc_name, nil)
-end
-
-# Facter command builder helper method
-def facter_cmd(cmd)
-  FACTER_BINPATH + cmd
-end
-
-# Used to cache the operation system information
-@cisco_os = nil
-# Use facter to return cisco operating system information
-def operating_system
-  return @cisco_os unless @cisco_os.nil?
-  if agent
-    @cisco_os = on(agent, facter_cmd('os.name')).stdout.chomp
-  else
-    output = `#{AGENTLESS_COMMAND} --facts | grep operatingsystem`
-    @cisco_os = output.match(%r{"operatingsystem": "(.*)"})[1]
-  end
-  @cisco_os
-end
-
-@os_family = nil
-def os_family
-  return @os_family unless @os_family.nil?
-  @os_family = on(agent, facter_cmd('os.family')).stdout.chomp
-end
-
-@virtual = nil
-def virtual
-  return @virtual unless @virtual.nil?
-  @virtual = on(agent, facter_cmd('virtual')).stdout.chomp
-end
-
-@system_manager = nil
-def system_manager
-  return @system_manager unless @system_manager.nil?
-  system_manager = on(agent, 'ls -l /proc/1/exe').stdout.chomp
-  # On NXOS hosting environments use different system_managers
-  # 1) Native bash-shell uses init
-  # 2) GuestShell uses systemd
-  # 3) OAC uses redhat
-  if system_manager[/systemd/]
-    @system_manager = 'systemd'
-  elsif platform[/n5k|n6k|n7k/]
-    @system_manager = 'redhat'
-  else
-    @system_manager = 'init'
-  end
-  @system_manager
-end
-
-# Used to cache the cisco hardware type
-@cisco_hardware = nil
-# Use facter to return cisco hardware type
-def platform
-  return @cisco_hardware unless @cisco_hardware.nil?
-  if agent
-    pi = on(agent, facter_cmd('-p cisco.hardware.type')).stdout.chomp
-    if pi.empty?
-      logger.debug 'Unable to query Cisco hardware type using the ' \
-        "'cisco.hardware.type' custom factor key"
-      # Some platforms do not respond correctly to the first command;
-      # make another attempt using a broader search.
-      on(agent, facter_cmd('-p cisco | egrep -A1 hardware'))
-      # Sample output:
-      #   hardware => {
-      #     type => "NX-OSv Chassis",
-      pi = Regexp.last_match[1] if stdout[/type => "(.*)"/]
-      fail 'Unable to query Cisco hardware type using facter commands' if
-        pi.empty?
-    end
-  else
-    output = `#{AGENTLESS_COMMAND} --facts | grep type`
-    pi = output.nil? ? '' : output.match(%r{"type": "(.*)"})[1]
   end
 
-  # The following kind of string info is returned for Nexus.
-  # - Nexus9000 C9396PX Chassis
-  # - Nexus7000 C7010 (10 Slot) Chassis
-  # - Nexus 6001 Chassis
-  # - NX-OSv Chassis
-  #
-  # The following kind of string info is returned for IOS XR.
-  # - Cisco XRv9K Virtual Router
-  case pi
-  when /Nexus\s?3\d\d\d/
-    @cisco_hardware = fretta? ? 'n3k-f' : 'n3k'
-  when /Nexus\s?5\d\d\d/
-    @cisco_hardware = 'n5k'
-  when /Nexus\s?6\d\d\d/
-    @cisco_hardware = 'n6k'
-  when /Nexus\s?7\d\d\d/
-    @cisco_hardware = 'n7k'
-  when /Nexus\s?9\d+\s\S+-EX/
-    @cisco_hardware = 'n9k-ex'
-  when /(Nexus\s?9\d\d\d|NX-OSv Chassis)/
-    @cisco_hardware = fretta? ? 'n9k-f' : 'n9k'
-  when /XRv9K/i
-    @cisco_hardware = 'xrv9k'
-  else
-    fail "Unrecognized platform type: #{pi}\n"
-  end
-  logger.info "\nFound Platform string: '#{pi}', Alias to: '#{@cisco_hardware}'"
-  @cisco_hardware
-end
-
-# fretta check
-@fretta_slot = nil
-def fretta?(reset_cache=false)
-  return @fretta_slot unless @fretta_slot.nil? || reset_cache
-  data = on(agent, facter_cmd('-p cisco.inventory')).output.split("\n")
-  @fretta_slot = false
-  data.each do |line|
-    next unless line.include?('pid =>')
-    @fretta_slot = true if line[/-R/]
-  end
-  @fretta_slot
-end
-
-# Check if image matches pattern
-@cached_img = nil
-def image?(reset_cache=false)
-  return @cached_img unless @cached_img.nil? || reset_cache
-  if agent
-    on(agent, facter_cmd('-p cisco.images.full_version'))
-    @cached_img = stdout.nil? ? '' : stdout
-  else
-    output = `#{AGENTLESS_COMMAND} --facts | grep full_version`
-    @cached_img = output.nil? ? '' : output.match(%r{"full_version": "(.*)"})[1]
-  end
-end
-
-@image = nil # Cache the lookup result
-def nexus_image
-  facter_opt = '-p cisco.images.full_version'
-  image_regexp = /(\S+)/
-  data = on(agent, facter_cmd(facter_opt)).output
-  darr = data.split("\n")
-  darr.each do |line|
-    next if line.include?('stty') || line.include?('WARN')
-    data = line
-  end
-  @image ||= image_regexp.match(data)[1]
-end
-
-# Gets the version of the image running on a device
-@version = nil
-def image_version
-  facter_opt = '-p os.release.full'
-  data = on(agent, facter_cmd(facter_opt)).stdout.chomp
-  @version ||= data
-end
-
-# Gets the full version of the image running on a device
-@full_ver = nil
-def full_version
-  facter_opt = '-p cisco.images.full_version'
-  data = on(agent, facter_cmd(facter_opt)).stdout.chomp
-  @full_ver ||= data
-end
-
-# On match will skip all testcases
-# Do not use this for skipping individual properties.
-def skip_nexus_image(image, tests)
-  return unless nexus_image.match(Regexp.union(image))
-  msg = "Skipping all tests; '#{tests[:resource_name]}' "\
-        "is not supported on #{image} images"
-  banner = '#' * msg.length
-  raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
-end
-
-# Helper to skip tests on unsupported platforms.
-# tests[:operating_system] - An OS regexp pattern for all tests (caller set)
-# tests[:platform] - A platform regexp pattern for all tests (caller set)
-# tests[id][:operating_system] - An OS regexp pattern for specific test (caller set)
-# tests[id][:platform] - A platform regexp pattern for specific test (caller set)
-# tests[:skipped] - A list of skipped tests (set by this method)
-def platform_supports_test(tests, id)
-  # Prefer specific test key over the all tests key
-  os = tests[id][:operating_system] || tests[:operating_system]
-  plat = tests[id][:platform] || tests[:platform]
-  if os && !operating_system.match(os)
-    logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
-    logger.error("Operating system does not match testcase os regexp: /#{os}/")
-  elsif plat && !platform.match(plat)
-    logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
-    logger.error("Platform type does not match testcase platform regexp: /#{plat}/")
-  else
-    unless agent.nil?
-      platform
-    end
-
-    return true
-  end
-  tests[:skipped] ||= []
-  tests[:skipped] << tests[id][:desc]
-  false
-end
-
-# This is a simple top-level skip similar to what exists in the minitests.
-# Callers will skip all tests when true.
-# tests[:platform] - regex of supported platforms
-# tests[:resource_name] - provider name (e.g. 'cisco_vxlan_vtep')
-def skip_unless_supported(tests)
-  pattern = tests[:platform]
-  return false if pattern.nil? || platform.match(tests[:platform])
-  msg = "Skipping all tests; '#{tests[:resource_name]}' "\
-        '(or test file) is not supported on this node'
-  banner = '#' * msg.length
-  raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
-end
-
-def skipped_tests_summary(tests)
-  return unless tests[:skipped]
-  logger.info("\n#{'-' * 60}\n  SKIPPED TESTS SUMMARY\n#{'-' * 60}")
-  tests[:skipped].each do |desc|
-    logger.error(sprintf('%-40s :: SKIP', desc))
-  end
-  # There are many tests now that skip a sub-test or two while the majority
-  # are still processed. We prefer to see the overall result as Pass instead
-  # of skip so skip the raise below.
-  # raise_skip_exception(tests[:resource_name], self)
-end
-
-# TBD: This needs to be more selective when used with modular platforms,
-# particularly to ignore L2-only F2 cards on N7k.
-# TBD: Remove the :intf_type requirement & change this to find_ethernet()
-#
-# Find a test interface on the agent.
-# Callers should include the following hash keys:
-#   [:agent]
-#   [:intf_type]
-#   [:resource_name]
-def find_interface(tests, id=nil, skipcheck=true)
-  logger.info("\n#{'-' * 60}\n  Find a suitable interface\n#{'-' * 60}")
-  # Prefer specific test key over the all tests key
-  if id
-    type = tests[id][:intf_type] || tests[:intf_type]
-  else
-    type = tests[:intf_type]
+  # Helper to raise skip when prereqs are not met
+  def prereq_skip(testheader, testcase, message)
+    testheader = '' if testheader.nil?
+    logger.error("** PLATFORM PREREQUISITE NOT MET: #{message}")
+    raise_skip_exception(testheader, testcase)
   end
 
-  case type
-  when /ethernet/i, /dot1q/
-    all = get_current_resource_instances(tests[:agent], 'cisco_interface')
-    # Skip the first interface we find in case it's our access interface.
-    # TODO: check the interface IP address like we do in node_utils
-    intf = all.grep(%r{ethernet\d+/\d+$})[1]
-
-  when /mgmt/i
-    all = get_current_resource_instances(tests[:agent], 'network_interface')
-    # TODO: check the interface IP address like we do in node_utils
-    intf = all.grep(/mgmt\d+$/)[0]
-  end
-
-  if skipcheck && intf.nil?
-    msg = 'Unable to find suitable interface module for this test.'
-    prereq_skip(tests[:resource_name], self, msg)
-  end
-  logger.info("\n  * Found #{intf}")
-  intf
-end
-
-# Find an array of test interface on the agent.
-# Callers should include the following hash keys:
-#   [:agent]
-#   [:intf_type]
-#   [:resource_name]
-def find_interface_array(tests, id=nil, skipcheck=true)
-  # Prefer specific test key over the all tests key
-  if id
-    type = tests[id][:intf_type] || tests[:intf_type]
-  else
-    type = tests[:intf_type]
-  end
-
-  case type
-  when /ethernet/i, /dot1q/
-    all = get_current_resource_instances(tests[:agent], 'cisco_interface')
-    # Skip the first interface we find in case it's our access interface.
-    # TODO: check the interface IP address like we do in node_utils
-    array = all.grep(%r{ethernet\d+/\d+})
-  end
-
-  if skipcheck && array.nil? && array.empty?
-    msg = 'Unable to find suitable interface module for this test.'
-    prereq_skip(tests[:resource_name], self, msg)
-  end
-  array
-end
-
-# Use puppet resource to get interface capability information.
-# TBD: Facter may be a better home for this method but the performance hit
-# appears to be 2s per hundred interfaces so it works better for now as an
-# on-demand method.
-def interface_capabilities(agent, intf)
-  if !agent.nil?
-    cmd = PUPPET_BINPATH + "resource cisco_interface_capabilities '#{intf}'"
+  # Some specific platform models do not support nv_overlay
+  def skip_if_nv_overlay_rejected(agent)
+    logger.info('Check for nv overlay support')
+    cmd = get_vshell_cmd('config t ; feature nv overlay')
     on(agent, cmd, pty: true)
-    output = stdout
-  else
-    output = `#{AGENTLESS_COMMAND} --resource cisco_interface_capabilities '#{intf}'`
+    # Failure message taken from 6001
+    msg = 'NVE Feature NOT supported on this Platform'
+    banner = '#' * msg.length
+    raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self) if
+      stdout.match(msg)
   end
 
-  # Sample raw output:
-  # "cisco_interface_capabilities { 'ethernet9/1':\n  capabilities =>
-  # ['Model: N7K-F312FQ-25', '', 'Type (SFP capable):    QSFP-40G-4SFP10G', '',
-  # 'Speed: 10000,40000', '', 'Duplex: full', ''], }
-
-  str = output[/\[(.*)\]/]
-  return {} if str.nil?
-  str = str[1..-2]
-  return {} if str.nil?
-  str = str[1..-2]
-  return {} if str.nil?
-
-  # 'Model: N7K-F312FQ-25', '', 'Type (SFP capable):    QSFP-40G-4SFP10G', '',
-  # 'Speed: 10000,40000', '', 'Duplex: full', ''
-  str.delete!("'")
-
-  # Model: N7K-F312FQ-25, , Type (SFP capable):    QSFP-40G-4SFP10G, ,
-  # Speed: 10000,40000, , Duplex: full, ,
-  hash = {}
-  str.split(', ,').each do |line|
-    k, v = line.split(':')
-    next if k.nil? || v.nil?
-    k.gsub!(/ \(.*\)/, '') # Remove any parenthetical text from key
-    k.strip!
-    v.strip!
-    v.gsub!(%r{half/full}, 'half,full') if k[/Duplex/]
-    hash[k] = v
-  end
-  hash
-end
-
-# Capabilities-to-Netdev-Manifest syntax converter
-def netdev_speed(speed)
-  case speed.to_s
-  when '100' then '100m'
-  when '1000' then '1g'
-  when '10000' then '10g'
-  when '40000' then '40g'
-  when '100000' then '100g'
-  else speed
-  end
-end
-
-def create_and_apply_test_manifest(type, title, property, value)
-  temp_manifest = Tempfile.new('temp_manifest')
-  unless value.match(/^(\d)+$/)
-    value = "'#{value}'"
-  end
-  temp_manifest.write("#{type} { '#{title}':
-                             #{property.to_s.downcase} => #{value},
-                           }\n")
-  temp_manifest.rewind
-
-  output = `#{AGENTLESS_COMMAND} --apply #{temp_manifest.path} 2>&1`
-
-  remove_temp_manifest(temp_manifest)
-  output
-end
-
-# 'interface_probe' tests reported capabilities. Why? Speed, duplex, and mtu
-# are somewhat unreliably reported (ie. some values still raise errors when
-# used) so this method tries each value to eliminate the ambiguity.
-# The probe options are passed in as a hash, either as a standalone argument or
-# via tests[:probe], in which case the successfully probed caps will overwrite
-# the tests[:probe][:caps] value.
-# Note that this function is only useful with ethernet interfaces.
-#
-# probe = A hash of probe arguments:
-#    :cmd = The puppet resource command to use with the probe.
-#    :intf = The interface to test. If not present one will be discovered.
-#    :caps = A hash of interface capabilities, typically the output from
-#            interface_capabilities(). If not present the capabilities will be
-#            discovered by this method. On completion, :caps will be updated
-#            with the successful values.
-#    :probe_props = An array of capabilities to probe.
-#    :netdev_speed = Set to True for syntax conversion (netdev only)
-#
-# Example:
-#   tests[:probe] = {
-#     cmd:         '<PUPPET_BINPATH> resource network_interface ',
-#     intf:        'ethernet1/1',
-#     caps:        {'Speed' => '10,100,1000', 'Duplex' => 'auto,half,full'},
-#     probe_props: %w(Speed Duplex)
-#
-def interface_probe(tests, probe={})
-  test_agent = tests[:agent]
-
-  # Use tests[:probe] if caller does not supply a separate probe hash
-  probe = tests[:probe] if probe.empty?
-  fail 'interface_probe: probe hash not found' if probe.nil?
-
-  # Find a usable interface
-  probe[:intf] = find_interface(tests) if probe[:intf].nil?
-  intf = probe[:intf]
-  fail 'interface_probe: interface not found' if intf.nil?
-
-  # Create the puppet resource command syntax
-  fail 'interface_probe: resource command not found' if probe[:cmd].nil?
-
-  if !test_agent.nil?
-    cmd = probe[:cmd] + " '#{intf}' "
-  else
-    cmd = "#{AGENTLESS_COMMAND} #{probe[:cmd].match(%r{.*\/puppet (.*)})} #{intf}"
+  # Return an interface name from the first MT-full compatible line module found
+  def mt_full_interface
+    # Search for F3 card on device, create an interface name if found
+    cmd = get_vshell_cmd('sh mod')
+    out = on(agent, cmd, pty: true).stdout[/^(\d+)\s.*N7[K7]-F3/]
+    slot = out.nil? ? nil : Regexp.last_match[1]
+    "ethernet#{slot}/1" unless slot.nil?
   end
 
-  # Get the interface capabilities
-  probe[:caps] = interface_capabilities(test_agent, intf) if probe[:caps].nil?
-  fail 'interface_probe: capabilities data not present' if probe[:caps].nil?
-
-  debug_probe(probe, 'Probe Begin')
-  probe[:probe_props].each do |prop|
-    success = []
-    probe[:caps][prop].to_s.split(',').each do |val|
-      val = netdev_speed(val) if prop[/Speed/] && probe[:netdev_speed]
-      if !test_agent.nil?
-        on(test_agent, cmd + "#{prop}=#{val}",
-           acceptable_exit_codes: [0, 2, 1], pty: true)
-        output = stdout
-      else
-        output = create_and_apply_test_manifest(probe[:cmd].match(%r{.*\/puppet resource (.*) })[1], intf, prop, val)
-      end
-      next if output[/error/i]
-      if val.match(/^(\d)+$/)
-        val = val.to_i
-      end
-      success << val
-    end
-    probe[:caps][prop] = success
+  # Return an interface name from the first Fabricpath compatible line module
+  # found
+  def fabricpath_interface
+    # Search for F2E/F3 cards on device, create an interface name if found
+    cmd = '-p cisco.feature_compatible_module_iflist.fabricpath'
+    if_array_str = on(agent, facter_cmd(cmd)).stdout.chomp
+    if_array_str.gsub!(/[\[\]\n\s"]/, '')
+    if_array = if_array_str.split(',')
+    if_array[0] unless if_array.empty?
   end
-  # probe[:caps]=>{"Speed"=>["100", "1000"], "Duplex"=>["full"],
-  debug_probe(probe, 'Probe Complete')
-  probe
-end
 
-def debug_probe(probe, msg)
-  dbg = ''
-  probe[:probe_props].each { |p| dbg += "'#{p}' => #{probe[:caps][p]}, " }
-  logger.info("\n      #{msg}: #{dbg}")
-end
-
-# Remove a single dynamic interface (Vlan, Loopback, Port-channel, etc).
-def remove_interface(agent, intf)
-  cmd = "    no interface #{intf.capitalize}"
-  command_config(agent, cmd, cmd)
-end
-
-# Issue a command on the agent and check stdout for a pattern.
-# Useful for checking if hardware supports properties, etc.
-def resource_probe(agent, cmd, pattern)
-  cmd = PUPPET_BINPATH + "resource #{cmd}"
-  on(agent, cmd, acceptable_exit_codes: [0, 2, 1], pty: true)
-  stdout.match(pattern) ? true : false
-end
-
-def vdc_limit_f3_no_intf_needed(action=:set)
-  # This is a special-use method for N7Ks that don't have a physical F3.
-  #  1) There are some features that refuse to load unless the VDC is
-  #     limited to F3 only, but they will actually load if the config is
-  #     present, despite the fact that there are no physical F3s.
-  #  2) We have some tests that need these features but don't need interfaces.
-  #
-  # action = :set (enable limit F3 config), :clear (default limit config)
-  #
-  # The limit config should be removed after testing if the device does not
-  # have an actual F3.
-  return unless platform[/n7k/]
-  case action
-  when :set
-    #  limit_resource_module_type => 'f3',
-    cmd = PUPPET_BINPATH + "resource cisco_vdc '#{default_vdc_name}' "
-    out = on(agent, cmd, pty: true).stdout[/limit_resource.*'(f3)'/]
-    mods = out.nil? ? nil : Regexp.last_match[1]
-    return if mods == 'f3'
-    cmd += "limit_resource_module_type='f3'"
-    logger.info("\n* Setup VDC: #{cmd}")
-    on(agent, cmd, pty: true).stdout[/limit_resource.*'(f3)'/]
-
-  when :clear
-    # Reset to default only if no physical F3 is present
-    teardown_vdc
+  # Return the default vdc name
+  def default_vdc_name
+    cmd = get_vshell_cmd('sh run vdc')
+    out = on(agent, cmd, pty: true).stdout[/^vdc (\S+) id 1$/]
+    out.nil? ? nil : Regexp.last_match[1]
   end
-end
 
-def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
-  # TBD: Modify this cleanup to use faster test_get / test_set:
-  #  test_get('i ^vlan|^bridge')
-  #  test_set('no vlan <range> ; no bridge <range> ; system bridge-domain none')
-  step "\n--------\n * TestStep :: #{stepinfo}" do
-    resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge domains')
-    cmd = 'system bridge-domain none'
-    command_config(agent, cmd, cmd)
-    test_set(agent, 'no feature interface-vlan')
-    test_set(agent, 'no feature private-vlan')
-    test_set(agent, 'no vlan 2-3967')
-  end
-end
-
-def remove_all_vrfs(agent)
-  # The output of test_get has changed in Puppet5 and newer versions of Puppet.
-  # Old output:
-  # cisco_command_config { 'cc':
-  #   test_get => '
-  # vrf context blue
-  # ',
-  # }
-  # New output:
-  # cisco_command_config { 'cc':
-  #   test_get => "\nvrf context blue\n",
-  # }
-  # The following logic handles both output styles.
-  found = test_get(agent, "incl 'vrf context' | excl management")
-  found.gsub!(/\\n/, ' ')
-  vrfs = found.scan(/(vrf context \S+)/)
-  return if vrfs.empty?
-  vrfs.flatten!.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
-  test_set(agent, vrfs.compact.join(' ; '))
-end
-
-# Return yum patch version from host
-def get_patch_version(name)
-  cmd = get_vshell_cmd("show install packages | inc #{name}")
-  # Sample Output:
-  # nxos.sample-n9k_EOR.lib32_n9000   1.0.0-7.0.3.I5.1    @patching
-  out = on(agent, cmd, pty: true).stdout[/\S+\s+(\S+).*@patching/]
-  out.nil? ? nil : Regexp.last_match[1]
-end
-
-# Test yum version
-def test_patch_version(tests, id, name, ver)
-  stepinfo = format_stepinfo(tests, id, 'YUM PACKAGE VERSION')
-  step "TestStep :: #{stepinfo}" do
-    logger.debug("test_yum_version :: #{ver}")
-    iv = get_patch_version(name)
-    if iv == ver
-      logger.info("#{stepinfo} :: PASS")
+  # Check for presence of limit-resource module-type
+  # The lookup is a loose match by default but some features like 'vni' are
+  # required to use a specific set of modules only, in which case specify
+  # ':exact' for a strict match of the current modules.
+  def limit_resource_module_type_get(vdc, mod, match=nil)
+    cmd = get_vshell_cmd("sh vdc #{vdc} detail")
+    if match == :exact
+      # Must be this list of modules only
+      pat = Regexp.new("vdc supported linecards: (#{mod})")
     else
-      msg = "Installed version: #{iv}, does not match expected ver: #{ver}"
-      fail_test("TestStep :: #{msg} :: FAIL")
+      # Just make sure module type is in list
+      pat = Regexp.new("vdc supported linecards:.*(#{mod})")
+    end
+    out = on(agent, cmd, pty: true).stdout.match(pat)
+    out.nil? ? nil : Regexp.last_match[1]
+  end
+
+  # Set limit-resource module-type
+  def limit_resource_module_type_set(vdc, mod, default=false)
+    mod = 'default' if default || mod.nil?
+    resource_vdc_mod = {
+      name:     'cisco_vdc',
+      title:    vdc,
+      property: 'limit_resource_module_type',
+      value:    mod,
+    }
+    resource_set(agent, resource_vdc_mod, "Enable module-type #{mod}")
+  end
+
+  # Check for presence of interface in vdc allocated interfaces
+  def vdc_allocate_interface_get(vdc, intf)
+    intf_pat = "(#{intf}) " # note trailing space
+    cmd = get_vshell_cmd("sh vdc #{vdc} membership")
+    out = on(agent, cmd, pty: true).stdout.match(
+      Regexp.new(intf_pat, Regexp::IGNORECASE))
+    out.nil? ? nil : Regexp.last_match[1]
+  end
+
+  # Add interface to vdc's allocated interfaces
+  def vdc_allocate_interface_set(vdc, intf)
+    # Turn off prompting
+    cmd = get_vshell_cmd('terminal dont-ask persist')
+    on(agent, cmd, pty: true)
+
+    cmd = get_vshell_cmd("conf t ; vdc #{vdc} ; "\
+                         "allocate interface #{intf}")
+    on(agent, cmd, pty: true)
+
+    # Reset prompting to default state
+    cmd = get_vshell_cmd('no terminal dont-ask persist')
+    on(agent, cmd, pty: true)
+  end
+
+  # VDC post-test cleanup
+  def teardown_vdc
+    return if mt_full_interface
+
+    # Testbeds without F3 cards should be set back to their default state;
+    # failure to do so will leave the testbed without usable interfaces.
+    # Assume that F3 testbeds should be left with module-type set to F3.
+    logger.info("\n* Teardown VDC: Reset limit-resource module-type")
+    limit_resource_module_type_set(default_vdc_name, nil)
+  end
+
+  # Facter command builder helper method
+  def facter_cmd(cmd)
+    FACTER_BINPATH + cmd
+  end
+
+  # Used to cache the operation system information
+  @cisco_os = nil
+  # Use facter to return cisco operating system information
+  def operating_system
+    return @cisco_os unless @cisco_os.nil?
+    if agent
+      @cisco_os = on(agent, facter_cmd('os.name')).stdout.chomp
+    else
+      output = `#{AGENTLESS_COMMAND} --facts | grep operatingsystem`
+      @cisco_os = output.match(%r{"operatingsystem": "(.*)"})[1]
+    end
+    @cisco_os
+  end
+
+  @os_family = nil
+  def os_family
+    return @os_family unless @os_family.nil?
+    @os_family = on(agent, facter_cmd('os.family')).stdout.chomp
+  end
+
+  @virtual = nil
+  def virtual
+    return @virtual unless @virtual.nil?
+    @virtual = on(agent, facter_cmd('virtual')).stdout.chomp
+  end
+
+  @system_manager = nil
+  def system_manager
+    return @system_manager unless @system_manager.nil?
+    system_manager = on(agent, 'ls -l /proc/1/exe').stdout.chomp
+    # On NXOS hosting environments use different system_managers
+    # 1) Native bash-shell uses init
+    # 2) GuestShell uses systemd
+    # 3) OAC uses redhat
+    if system_manager[/systemd/]
+      @system_manager = 'systemd'
+    elsif platform[/n5k|n6k|n7k/]
+      @system_manager = 'redhat'
+    else
+      @system_manager = 'init'
+    end
+    @system_manager
+  end
+
+  # Used to cache the cisco hardware type
+  @cisco_hardware = nil
+  # Use facter to return cisco hardware type
+  def platform
+    return @cisco_hardware unless @cisco_hardware.nil?
+    if agent
+      pi = on(agent, facter_cmd('-p cisco.hardware.type')).stdout.chomp
+      if pi.empty?
+        logger.debug 'Unable to query Cisco hardware type using the ' \
+          "'cisco.hardware.type' custom factor key"
+        # Some platforms do not respond correctly to the first command;
+        # make another attempt using a broader search.
+        on(agent, facter_cmd('-p cisco | egrep -A1 hardware'))
+        # Sample output:
+        #   hardware => {
+        #     type => "NX-OSv Chassis",
+        pi = Regexp.last_match[1] if stdout[/type => "(.*)"/]
+        fail 'Unable to query Cisco hardware type using facter commands' if
+          pi.empty?
+      end
+    else
+      output = `#{AGENTLESS_COMMAND} --facts | grep type`
+      pi = output.nil? ? '' : output.match(%r{"type": "(.*)"})[1]
+    end
+
+    # The following kind of string info is returned for Nexus.
+    # - Nexus9000 C9396PX Chassis
+    # - Nexus7000 C7010 (10 Slot) Chassis
+    # - Nexus 6001 Chassis
+    # - NX-OSv Chassis
+    #
+    # The following kind of string info is returned for IOS XR.
+    # - Cisco XRv9K Virtual Router
+    case pi
+    when /Nexus\s?3\d\d\d/
+      @cisco_hardware = fretta? ? 'n3k-f' : 'n3k'
+    when /Nexus\s?5\d\d\d/
+      @cisco_hardware = 'n5k'
+    when /Nexus\s?6\d\d\d/
+      @cisco_hardware = 'n6k'
+    when /Nexus\s?7\d\d\d/
+      @cisco_hardware = 'n7k'
+    when /Nexus\s?9\d+\s\S+-EX/
+      @cisco_hardware = 'n9k-ex'
+    when /(Nexus\s?9\d\d\d|NX-OSv Chassis)/
+      @cisco_hardware = fretta? ? 'n9k-f' : 'n9k'
+    when /XRv9K/i
+      @cisco_hardware = 'xrv9k'
+    else
+      fail "Unrecognized platform type: #{pi}\n"
+    end
+    logger.info "\nFound Platform string: '#{pi}', Alias to: '#{@cisco_hardware}'"
+    @cisco_hardware
+  end
+
+  # fretta check
+  @fretta_slot = nil
+  def fretta?(reset_cache=false)
+    return @fretta_slot unless @fretta_slot.nil? || reset_cache
+    data = on(agent, facter_cmd('-p cisco.inventory')).output.split("\n")
+    @fretta_slot = false
+    data.each do |line|
+      next unless line.include?('pid =>')
+      @fretta_slot = true if line[/-R/]
+    end
+    @fretta_slot
+  end
+
+  # Check if image matches pattern
+  @cached_img = nil
+  def image?(reset_cache=false)
+    return @cached_img unless @cached_img.nil? || reset_cache
+    if agent
+      on(agent, facter_cmd('-p cisco.images.full_version'))
+      @cached_img = stdout.nil? ? '' : stdout
+    else
+      output = `#{AGENTLESS_COMMAND} --facts | grep full_version`
+      @cached_img = output.nil? ? '' : output.match(%r{"full_version": "(.*)"})[1]
     end
   end
-end
 
-# Add double quotes to string.
-#
-# Helper method to add a double quote to the beginning
-# and end of a string.
-#
-# Nxapi adds an escape character to config lines that
-# nvgen in this way in some but not all nxos releases.
-#
-# Input: String (Example 'foo')
-# Returns: String with double quotes: (Example: '"foo"'
-#
-def add_quotes(string)
-  return string if image?[/7.3.0/]
-  string = "\"#{string}\""
-  string
+  @image = nil # Cache the lookup result
+  def nexus_image
+    facter_opt = '-p cisco.images.full_version'
+    image_regexp = /(\S+)/
+    data = on(agent, facter_cmd(facter_opt)).output
+    darr = data.split("\n")
+    darr.each do |line|
+      next if line.include?('stty') || line.include?('WARN')
+      data = line
+    end
+    @image ||= image_regexp.match(data)[1]
+  end
+
+  # Gets the version of the image running on a device
+  @version = nil
+  def image_version
+    facter_opt = '-p os.release.full'
+    data = on(agent, facter_cmd(facter_opt)).stdout.chomp
+    @version ||= data
+  end
+
+  # Gets the full version of the image running on a device
+  @full_ver = nil
+  def full_version
+    facter_opt = '-p cisco.images.full_version'
+    data = on(agent, facter_cmd(facter_opt)).stdout.chomp
+    @full_ver ||= data
+  end
+
+  # On match will skip all testcases
+  # Do not use this for skipping individual properties.
+  def skip_nexus_image(image, tests)
+    return unless nexus_image.match(Regexp.union(image))
+    msg = "Skipping all tests; '#{tests[:resource_name]}' "\
+          "is not supported on #{image} images"
+    banner = '#' * msg.length
+    raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
+  end
+
+  # Helper to skip tests on unsupported platforms.
+  # tests[:operating_system] - An OS regexp pattern for all tests (caller set)
+  # tests[:platform] - A platform regexp pattern for all tests (caller set)
+  # tests[id][:operating_system] - An OS regexp pattern for specific test (caller set)
+  # tests[id][:platform] - A platform regexp pattern for specific test (caller set)
+  # tests[:skipped] - A list of skipped tests (set by this method)
+  def platform_supports_test(tests, id)
+    # Prefer specific test key over the all tests key
+    os = tests[id][:operating_system] || tests[:operating_system]
+    plat = tests[id][:platform] || tests[:platform]
+    if os && !operating_system.match(os)
+      logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
+      logger.error("Operating system does not match testcase os regexp: /#{os}/")
+    elsif plat && !platform.match(plat)
+      logger.error("\n#{tests[id][:desc]} :: #{id} :: SKIP")
+      logger.error("Platform type does not match testcase platform regexp: /#{plat}/")
+    else
+      unless agent.nil?
+        platform
+      end
+
+      return true
+    end
+    tests[:skipped] ||= []
+    tests[:skipped] << tests[id][:desc]
+    false
+  end
+
+  # This is a simple top-level skip similar to what exists in the minitests.
+  # Callers will skip all tests when true.
+  # tests[:platform] - regex of supported platforms
+  # tests[:resource_name] - provider name (e.g. 'cisco_vxlan_vtep')
+  def skip_unless_supported(tests)
+    pattern = tests[:platform]
+    return false if pattern.nil? || platform.match(tests[:platform])
+    msg = "Skipping all tests; '#{tests[:resource_name]}' "\
+          '(or test file) is not supported on this node'
+    banner = '#' * msg.length
+    raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
+  end
+
+  def skipped_tests_summary(tests)
+    return unless tests[:skipped]
+    logger.info("\n#{'-' * 60}\n  SKIPPED TESTS SUMMARY\n#{'-' * 60}")
+    tests[:skipped].each do |desc|
+      logger.error(sprintf('%-40s :: SKIP', desc))
+    end
+    # There are many tests now that skip a sub-test or two while the majority
+    # are still processed. We prefer to see the overall result as Pass instead
+    # of skip so skip the raise below.
+    # raise_skip_exception(tests[:resource_name], self)
+  end
+
+  # TBD: This needs to be more selective when used with modular platforms,
+  # particularly to ignore L2-only F2 cards on N7k.
+  # TBD: Remove the :intf_type requirement & change this to find_ethernet()
+  #
+  # Find a test interface on the agent.
+  # Callers should include the following hash keys:
+  #   [:agent]
+  #   [:intf_type]
+  #   [:resource_name]
+  def find_interface(tests, id=nil, skipcheck=true)
+    logger.info("\n#{'-' * 60}\n  Find a suitable interface\n#{'-' * 60}")
+    # Prefer specific test key over the all tests key
+    if id
+      type = tests[id][:intf_type] || tests[:intf_type]
+    else
+      type = tests[:intf_type]
+    end
+
+    case type
+    when /ethernet/i, /dot1q/
+      all = get_current_resource_instances(tests[:agent], 'cisco_interface')
+      # Skip the first interface we find in case it's our access interface.
+      # TODO: check the interface IP address like we do in node_utils
+      intf = all.grep(%r{ethernet\d+/\d+$})[1]
+
+    when /mgmt/i
+      all = get_current_resource_instances(tests[:agent], 'network_interface')
+      # TODO: check the interface IP address like we do in node_utils
+      intf = all.grep(/mgmt\d+$/)[0]
+    end
+
+    if skipcheck && intf.nil?
+      msg = 'Unable to find suitable interface module for this test.'
+      prereq_skip(tests[:resource_name], self, msg)
+    end
+    logger.info("\n  * Found #{intf}")
+    intf
+  end
+
+  # Find an array of test interface on the agent.
+  # Callers should include the following hash keys:
+  #   [:agent]
+  #   [:intf_type]
+  #   [:resource_name]
+  def find_interface_array(tests, id=nil, skipcheck=true)
+    # Prefer specific test key over the all tests key
+    if id
+      type = tests[id][:intf_type] || tests[:intf_type]
+    else
+      type = tests[:intf_type]
+    end
+
+    case type
+    when /ethernet/i, /dot1q/
+      all = get_current_resource_instances(tests[:agent], 'cisco_interface')
+      # Skip the first interface we find in case it's our access interface.
+      # TODO: check the interface IP address like we do in node_utils
+      array = all.grep(%r{ethernet\d+/\d+})
+    end
+
+    if skipcheck && array.nil? && array.empty?
+      msg = 'Unable to find suitable interface module for this test.'
+      prereq_skip(tests[:resource_name], self, msg)
+    end
+    array
+  end
+
+  # Use puppet resource to get interface capability information.
+  # TBD: Facter may be a better home for this method but the performance hit
+  # appears to be 2s per hundred interfaces so it works better for now as an
+  # on-demand method.
+  def interface_capabilities(agent, intf)
+    if !agent.nil?
+      cmd = PUPPET_BINPATH + "resource cisco_interface_capabilities '#{intf}'"
+      on(agent, cmd, pty: true)
+      output = stdout
+    else
+      output = `#{AGENTLESS_COMMAND} --resource cisco_interface_capabilities '#{intf}'`
+    end
+
+    # Sample raw output:
+    # "cisco_interface_capabilities { 'ethernet9/1':\n  capabilities =>
+    # ['Model: N7K-F312FQ-25', '', 'Type (SFP capable):    QSFP-40G-4SFP10G', '',
+    # 'Speed: 10000,40000', '', 'Duplex: full', ''], }
+
+    str = output[/\[(.*)\]/]
+    return {} if str.nil?
+    str = str[1..-2]
+    return {} if str.nil?
+    str = str[1..-2]
+    return {} if str.nil?
+
+    # 'Model: N7K-F312FQ-25', '', 'Type (SFP capable):    QSFP-40G-4SFP10G', '',
+    # 'Speed: 10000,40000', '', 'Duplex: full', ''
+    str.delete!("'")
+
+    # Model: N7K-F312FQ-25, , Type (SFP capable):    QSFP-40G-4SFP10G, ,
+    # Speed: 10000,40000, , Duplex: full, ,
+    hash = {}
+    str.split(', ,').each do |line|
+      k, v = line.split(':')
+      next if k.nil? || v.nil?
+      k.gsub!(/ \(.*\)/, '') # Remove any parenthetical text from key
+      k.strip!
+      v.strip!
+      v.gsub!(%r{half/full}, 'half,full') if k[/Duplex/]
+      hash[k] = v
+    end
+    hash
+  end
+
+  # Capabilities-to-Netdev-Manifest syntax converter
+  def netdev_speed(speed)
+    case speed.to_s
+    when '100' then '100m'
+    when '1000' then '1g'
+    when '10000' then '10g'
+    when '40000' then '40g'
+    when '100000' then '100g'
+    else speed
+    end
+  end
+
+  def create_and_apply_test_manifest(type, title, property, value)
+    temp_manifest = Tempfile.new('temp_manifest')
+    unless value.match(/^(\d)+$/)
+      value = "'#{value}'"
+    end
+    temp_manifest.write("#{type} { '#{title}':
+                               #{property.to_s.downcase} => #{value},
+                             }\n")
+    temp_manifest.rewind
+
+    output = `#{AGENTLESS_COMMAND} --apply #{temp_manifest.path} 2>&1`
+
+    remove_temp_manifest(temp_manifest)
+    output
+  end
+
+  # 'interface_probe' tests reported capabilities. Why? Speed, duplex, and mtu
+  # are somewhat unreliably reported (ie. some values still raise errors when
+  # used) so this method tries each value to eliminate the ambiguity.
+  # The probe options are passed in as a hash, either as a standalone argument or
+  # via tests[:probe], in which case the successfully probed caps will overwrite
+  # the tests[:probe][:caps] value.
+  # Note that this function is only useful with ethernet interfaces.
+  #
+  # probe = A hash of probe arguments:
+  #    :cmd = The puppet resource command to use with the probe.
+  #    :intf = The interface to test. If not present one will be discovered.
+  #    :caps = A hash of interface capabilities, typically the output from
+  #            interface_capabilities(). If not present the capabilities will be
+  #            discovered by this method. On completion, :caps will be updated
+  #            with the successful values.
+  #    :probe_props = An array of capabilities to probe.
+  #    :netdev_speed = Set to True for syntax conversion (netdev only)
+  #
+  # Example:
+  #   tests[:probe] = {
+  #     cmd:         '<PUPPET_BINPATH> resource network_interface ',
+  #     intf:        'ethernet1/1',
+  #     caps:        {'Speed' => '10,100,1000', 'Duplex' => 'auto,half,full'},
+  #     probe_props: %w(Speed Duplex)
+  #
+  def interface_probe(tests, probe={})
+    test_agent = tests[:agent]
+
+    # Use tests[:probe] if caller does not supply a separate probe hash
+    probe = tests[:probe] if probe.empty?
+    fail 'interface_probe: probe hash not found' if probe.nil?
+
+    # Find a usable interface
+    probe[:intf] = find_interface(tests) if probe[:intf].nil?
+    intf = probe[:intf]
+    fail 'interface_probe: interface not found' if intf.nil?
+
+    # Create the puppet resource command syntax
+    fail 'interface_probe: resource command not found' if probe[:cmd].nil?
+
+    if !test_agent.nil?
+      cmd = probe[:cmd] + " '#{intf}' "
+    else
+      cmd = "#{AGENTLESS_COMMAND} #{probe[:cmd].match(%r{.*\/puppet (.*)})} #{intf}"
+    end
+
+    # Get the interface capabilities
+    probe[:caps] = interface_capabilities(test_agent, intf) if probe[:caps].nil?
+    fail 'interface_probe: capabilities data not present' if probe[:caps].nil?
+
+    debug_probe(probe, 'Probe Begin')
+    probe[:probe_props].each do |prop|
+      success = []
+      probe[:caps][prop].to_s.split(',').each do |val|
+        val = netdev_speed(val) if prop[/Speed/] && probe[:netdev_speed]
+        if !test_agent.nil?
+          on(test_agent, cmd + "#{prop}=#{val}",
+             acceptable_exit_codes: [0, 2, 1], pty: true)
+          output = stdout
+        else
+          output = create_and_apply_test_manifest(probe[:cmd].match(%r{.*\/puppet resource (.*) })[1], intf, prop, val)
+        end
+        next if output[/error/i]
+        if val.match(/^(\d)+$/)
+          val = val.to_i
+        end
+        success << val
+      end
+      probe[:caps][prop] = success
+    end
+    # probe[:caps]=>{"Speed"=>["100", "1000"], "Duplex"=>["full"],
+    debug_probe(probe, 'Probe Complete')
+    probe
+  end
+
+  def debug_probe(probe, msg)
+    dbg = ''
+    probe[:probe_props].each { |p| dbg += "'#{p}' => #{probe[:caps][p]}, " }
+    logger.info("\n      #{msg}: #{dbg}")
+  end
+
+  # Remove a single dynamic interface (Vlan, Loopback, Port-channel, etc).
+  def remove_interface(agent, intf)
+    cmd = "    no interface #{intf.capitalize}"
+    command_config(agent, cmd, cmd)
+  end
+
+  # Issue a command on the agent and check stdout for a pattern.
+  # Useful for checking if hardware supports properties, etc.
+  def resource_probe(agent, cmd, pattern)
+    cmd = PUPPET_BINPATH + "resource #{cmd}"
+    on(agent, cmd, acceptable_exit_codes: [0, 2, 1], pty: true)
+    stdout.match(pattern) ? true : false
+  end
+
+  def vdc_limit_f3_no_intf_needed(action=:set)
+    # This is a special-use method for N7Ks that don't have a physical F3.
+    #  1) There are some features that refuse to load unless the VDC is
+    #     limited to F3 only, but they will actually load if the config is
+    #     present, despite the fact that there are no physical F3s.
+    #  2) We have some tests that need these features but don't need interfaces.
+    #
+    # action = :set (enable limit F3 config), :clear (default limit config)
+    #
+    # The limit config should be removed after testing if the device does not
+    # have an actual F3.
+    return unless platform[/n7k/]
+    case action
+    when :set
+      #  limit_resource_module_type => 'f3',
+      cmd = PUPPET_BINPATH + "resource cisco_vdc '#{default_vdc_name}' "
+      out = on(agent, cmd, pty: true).stdout[/limit_resource.*'(f3)'/]
+      mods = out.nil? ? nil : Regexp.last_match[1]
+      return if mods == 'f3'
+      cmd += "limit_resource_module_type='f3'"
+      logger.info("\n* Setup VDC: #{cmd}")
+      on(agent, cmd, pty: true).stdout[/limit_resource.*'(f3)'/]
+
+    when :clear
+      # Reset to default only if no physical F3 is present
+      teardown_vdc
+    end
+  end
+
+  def remove_all_vlans(agent, stepinfo='Remove all vlans & bridge-domains')
+    # TBD: Modify this cleanup to use faster test_get / test_set:
+    #  test_get('i ^vlan|^bridge')
+    #  test_set('no vlan <range> ; no bridge <range> ; system bridge-domain none')
+    step "\n--------\n * TestStep :: #{stepinfo}" do
+      resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge domains')
+      cmd = 'system bridge-domain none'
+      command_config(agent, cmd, cmd)
+      test_set(agent, 'no feature interface-vlan')
+      test_set(agent, 'no feature private-vlan')
+      test_set(agent, 'no vlan 2-3967')
+    end
+  end
+
+  def remove_all_vrfs(agent)
+    # The output of test_get has changed in Puppet5 and newer versions of Puppet.
+    # Old output:
+    # cisco_command_config { 'cc':
+    #   test_get => '
+    # vrf context blue
+    # ',
+    # }
+    # New output:
+    # cisco_command_config { 'cc':
+    #   test_get => "\nvrf context blue\n",
+    # }
+    # The following logic handles both output styles.
+    found = test_get(agent, "incl 'vrf context' | excl management")
+    found.gsub!(/\\n/, ' ')
+    vrfs = found.scan(/(vrf context \S+)/)
+    return if vrfs.empty?
+    vrfs.flatten!.map! { |cmd| "no #{cmd}" if cmd[/^?\n?vrf context/] }
+    test_set(agent, vrfs.compact.join(' ; '))
+  end
+
+  # Return yum patch version from host
+  def get_patch_version(name)
+    cmd = get_vshell_cmd("show install packages | inc #{name}")
+    # Sample Output:
+    # nxos.sample-n9k_EOR.lib32_n9000   1.0.0-7.0.3.I5.1    @patching
+    out = on(agent, cmd, pty: true).stdout[/\S+\s+(\S+).*@patching/]
+    out.nil? ? nil : Regexp.last_match[1]
+  end
+
+  # Test yum version
+  def test_patch_version(tests, id, name, ver)
+    stepinfo = format_stepinfo(tests, id, 'YUM PACKAGE VERSION')
+    step "TestStep :: #{stepinfo}" do
+      logger.debug("test_yum_version :: #{ver}")
+      iv = get_patch_version(name)
+      if iv == ver
+        logger.info("#{stepinfo} :: PASS")
+      else
+        msg = "Installed version: #{iv}, does not match expected ver: #{ver}"
+        fail_test("TestStep :: #{msg} :: FAIL")
+      end
+    end
+  end
+
+  # Add double quotes to string.
+  #
+  # Helper method to add a double quote to the beginning
+  # and end of a string.
+  #
+  # Nxapi adds an escape character to config lines that
+  # nvgen in this way in some but not all nxos releases.
+  #
+  # Input: String (Example 'foo')
+  # Returns: String with double quotes: (Example: '"foo"'
+  #
+  def add_quotes(string)
+    return string if image?[/7.3.0/]
+    string = "\"#{string}\""
+    string
+  end
 end

--- a/tests/beaker_tests/ntp_server/test_ntp_server.rb
+++ b/tests/beaker_tests/ntp_server/test_ntp_server.rb
@@ -65,8 +65,8 @@ tests[:non_default] = {
 }
 
 # class to properly handle unsupported properties for this test case
-class TestNtpServer
-  def self.unsupported_properties(*)
+class TestNtpServer < BaseHarness
+  def self.unsupported_properties(_ctx, _tests, _id)
     unprops = []
     unprops << :source_interface
     unprops


### PR DESCRIPTION
This commit moves all utilitylib functions into the Beaker::TestCase class.
By doing this the methods stay available to each test, but are shielded
from each other.

To pass test-specific functionality into the utilitylib, a special harness
class can be provided.