### PR TITLE
(maint) regression during conversion on agent

### DIFF
--- a/tests/beaker_tests/cisco_tacacs_server/test_tacacs_server.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/test_tacacs_server.rb
@@ -83,7 +83,7 @@ tests[:negative_timeout] = {
   },
   resource: {
   },
-  code: [1, 4],
+  code: [4],
 }
 
 tests[:negative_deadtime] = {
@@ -94,7 +94,7 @@ tests[:negative_deadtime] = {
   },
   resource: {
   },
-  code: [1, 4],
+  code: [4],
 }
 
 #################################################################
@@ -103,7 +103,7 @@ tests[:negative_deadtime] = {
 test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, skip_idempotence_check: true)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non-Default Property Testing")
   test_harness_run(tests, :non_default)

--- a/tests/beaker_tests/cisco_tacacs_server_host/test_tacacs_server_host.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/test_tacacs_server_host.rb
@@ -75,7 +75,7 @@ tests[:negative_port] = {
   },
   resource: {
   },
-  code: [1, 4],
+  code: [6],
 }
 
 tests[:negative_timeout] = {
@@ -87,7 +87,7 @@ tests[:negative_timeout] = {
   },
   resource: {
   },
-  code: [1, 4],
+  code: [6],
 }
 
 tests[:negative_password] = {
@@ -101,7 +101,7 @@ tests[:negative_password] = {
   },
   resource: {
   },
-  code: [1, 4],
+  code: [6],
 }
 
 def cleanup(agent)
@@ -117,7 +117,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   cleanup(agent)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
-  test_harness_run(tests, :default)
+  test_harness_run(tests, :default, skip_idempotence_check: true)
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 2. Non-Default Property Testing")
   test_harness_run(tests, :non_default)


### PR DESCRIPTION
When running on agent the incorrect codes were being checked and idempotency was not checked previously for 'defaults' as changes are expected.