### PR TITLE
(FM-7550) conversion of the itd_service tests to dual mode

### DIFF
--- a/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
+++ b/tests/beaker_tests/cisco_itd_service/test_itd_service.rb
@@ -207,28 +207,28 @@ tests[:non_default_shut_4] = {
   },
 }
 
-def cleanup(agent)
-  cmds = ['no ip access-list iap',
-          'no ip access-list eap',
-          'no vlan 2',
-          'no interface port-channel 100',
-          'no feature interface-vlan',
-          'no feature itd',
-         ].join(' ; ')
-  test_set(agent, cmds)
-  interface_cleanup(agent, @ingress_eth_int)
-end
-
 # class to contain the test_harness_dependencies
 class TestItdService < BaseHarness
+  def self.cleanup(ctx)
+    cmds = ['no ip access-list iap',
+            'no ip access-list eap',
+            'no vlan 2',
+            'no interface port-channel 100',
+            'no feature interface-vlan',
+            'no feature itd',
+           ].join(' ; ')
+    ctx.test_set(ctx.agent, cmds)
+    ctx.interface_cleanup(ctx.agent, ctx.instance_variable_get(:@ingress_eth_int))
+  end
+
   def self.test_harness_dependencies(ctx, _tests, _id)
-    cleanup(agent)
+    cleanup(ctx)
 
     cmd = [
       'feature itd',
       'feature interface-vlan',
       'ip access-list iap ; ip access-list eap',
-      "interface #{@ingress_eth_int} ; no switchport",
+      "interface #{ctx.instance_variable_get(:@ingress_eth_int)} ; no switchport",
       'vlan 2 ; interface vlan 2',
       'interface port-channel 100 ; no switchport',
       'itd device-group udpGroup ; node ip 1.1.1.1',
@@ -241,8 +241,8 @@ end
 # TEST CASE EXECUTION
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
-  teardown { cleanup(agent) }
-  cleanup(agent)
+  teardown { TestItdService.cleanup(self) }
+  TestItdService.cleanup(self)
 
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")


### PR DESCRIPTION
These are long tests as each test does a clean up before execution of each individual test set.