### PR TITLE
(maint) fix for the failures on the presuite deploy

### DIFF
--- a/tests/beaker_tests/presuite/presuite_deploy.rb
+++ b/tests/beaker_tests/presuite/presuite_deploy.rb
@@ -160,11 +160,8 @@ test_name 'Prep Masters & Install Puppet' do
         on(switch, 'rm /etc/puppetlabs/puppet/puppet.conf')
         on(switch, 'touch /etc/puppetlabs/puppet/puppet.conf')
         on(switch, 'chmod a+w /etc/puppetlabs/puppet/puppet.conf')
-        on(switch, 'echo -e "[main]" >> /etc/puppetlabs/puppet/puppet.conf')
-        on(switch, "echo -e \"  server = #{master.hostname}\n\" >> /etc/puppetlabs/puppet/puppet.conf")
-        on(switch, 'echo -e "[agent]" >> /etc/puppetlabs/puppet/puppet.conf')
-        on(switch, 'echo -e "  pluginsync  = true" >> /etc/puppetlabs/puppet/puppet.conf')
-        on(switch, "/opt/puppetlabs/bin/puppet agent -t --server #{master.hostname}", acceptable_exit_codes: [1])
+        on(switch, "/opt/puppetlabs/bin/puppet config set server #{master.hostname}")
+        on(switch, '/opt/puppetlabs/bin/puppet agent -t', acceptable_exit_codes: [1])
         unless masters.empty?
           on(master, puppet('cert', 'sign', switch.to_s), acceptable_exit_codes: [0, 1])
         end


### PR DESCRIPTION
With Beaker 4.2.0 there were changes to how the appending of `"` occured which resulted in the echoing of server information to conf file to be incorrectly performed.

```
Beaker::Host::CommandFailure: Host 'cisco-c9372.delivery.puppetlabs.net' exited with 127 running:
09:55:06  source /etc/profile; sudo -E sh -c "ip netns exec management echo -e "  server = shogb044jljqggb.delivery.puppetlabs.net
09:55:06 " >> /etc/puppetlabs/puppet/puppet.conf "
09:55:06 Last 10 lines of output were:
```

With this commit change it correctly sets the server information using the `puppet config set` functionality:

```
x0z28wzrmrw8kkb.delivery.puppetlabs.net (cisconx-64-1) 12:32:27$ source /etc/profile; sudo -E sh -c "ip netns exec management /opt/puppetlabs/bin/puppet config set server rs820lgn6573r9l.delivery.puppetlabs.net "

x0z28wzrmrw8kkb.delivery.puppetlabs.net (cisconx-64-1) executed in 1.87 seconds
```