### PR TITLE
(MODULES-8232) fixes for snmp notification receiver to support unsetting

### DIFF
--- a/lib/puppet/provider/snmp_notification_receiver/cisco_nexus.rb
+++ b/lib/puppet/provider/snmp_notification_receiver/cisco_nexus.rb
@@ -16,6 +16,9 @@ require 'puppet/resource_api/simple_provider'
 # Implementation for the snmp_notification_receiver type using the Resource API.
 class Puppet::Provider::SnmpNotificationReceiver::CiscoNexus < Puppet::ResourceApi::SimpleProvider
   def canonicalize(_context, resources)
+    resources.each do |resource|
+      resource[:port] = nil if resource[:port] == (-1 || 'unset')
+    end
     resources
   end
 
@@ -53,6 +56,9 @@ class Puppet::Provider::SnmpNotificationReceiver::CiscoNexus < Puppet::ResourceA
 
   def update(context, name, should)
     validate_should(should)
+    # existing receiver needs to be deleted before updating
+    @snmp_notification_receivers ||= Cisco::SnmpNotificationReceiver.receivers
+    @snmp_notification_receivers[name].destroy if @snmp_notification_receivers[name]
     context.notice("Setting '#{name}' with #{should.inspect}")
     Cisco::SnmpNotificationReceiver.new(name,
                                         instantiate:      true,
@@ -69,6 +75,8 @@ class Puppet::Provider::SnmpNotificationReceiver::CiscoNexus < Puppet::ResourceA
 
   def munge(val)
     if val.is_a?(String) && val.eql?('unset')
+      nil
+    elsif val.is_a?(Integer) && val.eql?(-1)
       nil
     elsif val.is_a?(Integer)
       val.to_s

--- a/spec/unit/puppet/provider/radius/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/radius/cisco_nexus_spec.rb
@@ -6,6 +6,7 @@ require 'puppet/provider/radius/cisco_nexus'
 
 RSpec.describe Puppet::Provider::Radius::CiscoNexus do
   subject(:provider) { described_class.new }
+
   let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
   let(:device) { instance_double('Puppet::Util::NetworkDevice::Nexus::Device', 'device') }
 

--- a/spec/unit/puppet/provider/snmp_notification_receiver/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/snmp_notification_receiver/cisco_nexus_spec.rb
@@ -202,6 +202,9 @@ RSpec.describe Puppet::Provider::SnmpNotificationReceiver::CiscoNexus do
       expect(provider.munge(46)).to eq '46'
     }
     it {
+      expect(provider.munge(-1)).to eq nil
+    }
+    it {
       expect(provider.munge('unset')).to eq nil
     }
     it {


### PR DESCRIPTION
The existing code allowed you to unset a value through -1/unset and was missed during the conversion.

Changes still need to happen to netdev_stdlib to support this.

The deletion of the existing snmp receiver was missed during conversion and meant that multiple receivers with same host/name would be created causing problems.