### PR TITLE
(MODULES-8232) fixes for snmp notification receiver to support unsetting

### DIFF
--- a/spec/unit/puppet/provider/radius/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/radius/cisco_nexus_spec.rb
@@ -6,6 +6,7 @@ require 'puppet/provider/radius/cisco_nexus'
 
 RSpec.describe Puppet::Provider::Radius::CiscoNexus do
   subject(:provider) { described_class.new }
+
   let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
   let(:device) { instance_double('Puppet::Util::NetworkDevice::Nexus::Device', 'device') }
 


### PR DESCRIPTION
The existing code allowed you to unset a value through -1/unset and was missed during the conversion.

Changes still need to happen to netdev_stdlib to support this fully. 

The deletion of the existing snmp receiver was missed during conversion and meant that multiple receivers with same host/name would be created causing problems.

In order to keep idempotency the `get` will return `unset` for `vrf`, `source_interface`, and `port` if the values are `nil`.

```
snmp_notification_receiver { '2.3.4.5':
  ensure => 'present',
  port => 'unset',
  username => 'admin',
  version => 'v3',
  type => 'traps',
  security => 'priv',
  vrf => 'management',
  source_interface => 'unset',
}
```