### PR TITLE
(MODULES-8232) fixes to idempotency for radius_server when unsetting

### DIFF
--- a/lib/puppet/provider/radius_server/cisco_nexus.rb
+++ b/lib/puppet/provider/radius_server/cisco_nexus.rb
@@ -25,11 +25,15 @@ class Puppet::Provider::RadiusServer::CiscoNexus < Puppet::ResourceApi::SimplePr
   def canonicalize(_context, resources)
     resources.each do |resource|
       resource[:key] = resource[:key].gsub(/\A"|"\Z/, '') if resource[:key]
+      resource[:key] = 'unset' if resource[:key].nil?
+      resource[:timeout] = 'unset' if resource[:timeout].nil? || resource[:timeout] == (nil || -1)
+      resource[:key_format] = 'unset' if resource[:key_format].nil? || resource[:key_format] == (nil || -1)
+      resource[:retransmit_count] = 'unset' if resource[:retransmit_count].nil? || resource[:retransmit_count] == (nil || -1)
     end
     resources
   end
 
-  RADIUS_SERVER_PROPS = {
+  RADIUS_SERVER_PROPS ||= {
     auth_port:           :auth_port,
     acct_port:           :acct_port,
     timeout:             :timeout,
@@ -38,7 +42,7 @@ class Puppet::Provider::RadiusServer::CiscoNexus < Puppet::ResourceApi::SimplePr
     authentication_only: :authentication,
   }
 
-  UNSUPPORTED_PROPS = [:group, :deadtime, :vrf, :source_interface]
+  UNSUPPORTED_PROPS ||= [:group, :deadtime, :vrf, :source_interface]
 
   def get(context, _names=nil)
     require 'cisco_node_utils'
@@ -50,10 +54,10 @@ class Puppet::Provider::RadiusServer::CiscoNexus < Puppet::ResourceApi::SimplePr
         name:                 v.name,
         auth_port:            v.auth_port ? v.auth_port : nil,
         acct_port:            v.acct_port ? v.acct_port : nil,
-        timeout:              v.timeout ? v.timeout : -1,
-        retransmit_count:     v.retransmit_count ? v.retransmit_count : -1,
+        timeout:              v.timeout ? v.timeout : 'unset',
+        retransmit_count:     v.retransmit_count ? v.retransmit_count : 'unset',
         key:                  v.key ? v.key.gsub(/\A"|"\Z/, '') : 'unset',
-        key_format:           v.key_format ? v.key_format : -1,
+        key_format:           v.key_format ? v.key_format.to_i : 'unset',
         accounting_only:      v.accounting,
         authentication_only:  v.authentication
       }

--- a/spec/unit/puppet/provider/radius_server/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/radius_server/cisco_nexus_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe Puppet::Provider::RadiusServer::CiscoNexus do
           name:             '1.2.3.4',
           auth_port:        1812,
           acct_port:        1813,
-          timeout:          -1,
-          retransmit_count: -1,
+          timeout:          'unset',
+          retransmit_count: 'unset',
           key:              'unset',
-          key_format:       -1,
+          key_format:       'unset',
           accounting_only:  true,
           authentication_only: false,
         },
@@ -127,7 +127,7 @@ RSpec.describe Puppet::Provider::RadiusServer::CiscoNexus do
                                           timeout: -1)
     end
   end
-  #
+
   describe '#update' do
     it 'updates the resource' do
       expect(context).to receive(:notice).with(%r{\Updating '1.2.3.4'}).once
@@ -348,12 +348,105 @@ RSpec.describe Puppet::Provider::RadiusServer::CiscoNexus do
         name:             'default',
         timeout:          7,
         retransmit_count: 3,
+        key_format:       7,
         source_interface: ['foo'],
       }],
       results: [{
         name:             'default',
         timeout:          7,
         retransmit_count: 3,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+    },
+    {
+      desc: '`resources` contains the "unset" key value',
+      resources: [{
+        name:             'default',
+        timeout:          7,
+        retransmit_count: 3,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+      results: [{
+        name:             'default',
+        timeout:          7,
+        retransmit_count: 3,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+    },
+    {
+      desc: '`resources` does not contain the timeout value',
+      resources: [{
+        name:             'default',
+        retransmit_count: 3,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+      results: [{
+        name:             'default',
+        timeout:          'unset',
+        retransmit_count: 3,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+    },
+    {
+      desc: '`resources` contains -1 timeout value',
+      resources: [{
+        name:             'default',
+        retransmit_count: 3,
+        timeout: -1,
+        key: 'unset',
+        key_format:       7,
+        source_interface: ['foo'],
+      }],
+      results: [{
+        name:             'default',
+        timeout:          'unset',
+        key_format:       7,
+        retransmit_count: 3,
+        key: 'unset',
+        source_interface: ['foo'],
+      }],
+    },
+    {
+      desc: '`resources` contains -1 values',
+      resources: [{
+        name:             'default',
+        retransmit_count: -1,
+        timeout: -1,
+        key: 'unset',
+        key_format:       -1,
+        source_interface: ['foo'],
+      }],
+      results: [{
+        name:             'default',
+        timeout:          'unset',
+        key_format:       'unset',
+        retransmit_count: 'unset',
+        key: 'unset',
+        source_interface: ['foo'],
+      }],
+    },
+    {
+      desc: '`resources` does not contain unsettable values',
+      resources: [{
+        name:             'default',
+        source_interface: ['foo'],
+      }],
+      results: [{
+        name:             'default',
+        timeout:          'unset',
+        key_format:       'unset',
+        retransmit_count: 'unset',
+        key: 'unset',
         source_interface: ['foo'],
       }],
     },

--- a/tests/beaker_tests/radius_server/test_radius_server.rb
+++ b/tests/beaker_tests/radius_server/test_radius_server.rb
@@ -65,6 +65,16 @@ tests[:manifest_present_change] = {
     retransmit_count: -1,
     timeout: -1,
   },
+  resource: {
+    ensure: 'present',
+    accounting_only: false,
+    acct_port: 44,
+    auth_port: 55,
+    authentication_only: true,
+    key: 'unset',
+    retransmit_count: 'unset',
+    timeout: 'unset',
+  },
   code:           [0, 2],
 }
 


### PR DESCRIPTION
Unsetting some paramaters is available, but was failing idempotency.

This change will be dependent on some changes to netdev_stdlib which means it will most likely fail on travis.

The `get` will return `unset` for values which have not been set/unset at some point.