### PR TITLE
(maint) typo fix for provisioning puppet server

### DIFF
--- a/tests/beaker_presuite/presuite_deploy.rb
+++ b/tests/beaker_presuite/presuite_deploy.rb
@@ -50,7 +50,7 @@ test_name 'Prep Masters & Install Puppet' do
   unless ENV['BEAKER_provision'] == 'no' || masters.empty?
     step 'install PE on masters' do
       masters.each do |node|
-        if node.options['provison']
+        if node.options['provision']
           install_pe_on(masters, {})
         end
       end


### PR DESCRIPTION
Verified using:

```
BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2018.1.0
BEAKER_PE_VER=2018.1.0
BEAKER_PUPPET_AGENT_VERSION=5.5.1
SHA=5.5.1 MODULE_URL=https://github.com/puppetlabs/cisco-network-puppet-module.git MODULE_REF=puppet6
export BEAKER_PE_DIR BEAKER_PE_VER BEAKER_PUPPET_AGENT_VERSION SHA MODULE_URL MODULE_REF
bundle exec beaker --color --debug --hosts hosts.yml --pre-suite tests/beaker_presuite/presuite_deploy.rb -t tests/beaker_tests/banner/test_banner.rb --keyfile ~/.ssh/id_rsa-acceptance
```

Which matches our Jenkins configuration.