### PR TITLE
(maint) pdksync to resolve the gemset issues on Puppet 4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 language: ruby
 cache: bundler
 before_install:
+  - if [ $BUNDLER_VERSION ]; then
+      gem install -v $BUNDLER_VERSION bundler --no-rdoc --no-ri;
+    fi
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system $RUBYGEMS_VERSION
@@ -27,7 +30,7 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
     -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
       rvm: 2.1.9
 branches:
   only:

--- a/metadata.json
+++ b/metadata.json
@@ -50,5 +50,5 @@
   ],
   "pdk-version": "1.8.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates/",
-  "template-ref": "heads/master-0-g20af4c6"
+  "template-ref": "heads/master-0-g9c815ea"
 }


### PR DESCRIPTION
Bundler was removed from the rubygems < 3.0.0 gemset, so a pdk template change was made which we now need to use.