### PR TITLE
(maint) knocking out /bin/ from pdksync

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -8,7 +8,6 @@
 /.idea/
 /.vagrant/
 /coverage/
-/bin/
 /doc/
 /Gemfile.local
 /Gemfile.lock

--- a/.sync.yml
+++ b/.sync.yml
@@ -21,6 +21,10 @@ Gemfile:
           - mingw
           - x64_mingw
 .gitignore:
+  # need to ensure /bin/ is not ignored
+  # and is under the required keys
+  required:
+    - ---/bin/
   paths:
     - junit/
     - hosts.cfg
@@ -28,6 +32,7 @@ Gemfile:
     - /spec/fixtures/acceptance-device.conf
 .pdkignore:
   paths:
+    - ---/bin/
     - junit/
     - hosts.cfg
     - /spec/fixtures/acceptance-credentials.conf

--- a/metadata.json
+++ b/metadata.json
@@ -50,5 +50,5 @@
   ],
   "pdk-version": "1.8.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates/",
-  "template-ref": "heads/master-0-g9c815ea"
+  "template-ref": "heads/master-0-gd61c0a4"
 }


### PR DESCRIPTION
`/bin/` is a required gitignore file that we have previously had to manually remove from the .gitignore after preforming a pdksync/update.

This change will mean that the /bin/ folder stays out of .gitignore.