### PR TITLE
utilitylib.rb: remove_all_vlans ignore_errors: true

### DIFF
--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1906,7 +1906,7 @@ DEVICE
       resource_absent_cleanup(agent, 'cisco_bridge_domain', 'bridge domains')
       # bridge_domain feature is available only on n7k
       command_config(agent, 'system bridge-domain none', 'system bridge-domain none',
-                     ignore_errors: false) if platform == 'n7k'
+                     ignore_errors: true) if platform == 'n7k'
       test_set(agent, 'no feature interface-vlan')
       test_set(agent, 'no feature private-vlan')
       test_set(agent, 'no vlan 2-3967')


### PR DESCRIPTION
Some of the 7k-based beaker tests were failing while removing a non-existent bridge-domain config. 
These were the failing tests, which are now passing:

```
test_bridge_domain_vni.rb
test_fabricpath_global.rb
test_fabricpath_topology.rb
test_interface_bdi.rb
test_interface_stp.rb
test_stp_global.rb
test_private_vlan.rb
test_vlan.rb
test_vpc_domain.rb
```

