### PR TITLE
(FM-7680) fix for the management of hostname when it should not be

### DIFF
--- a/lib/puppet/provider/network_dns/cisco_nexus.rb
+++ b/lib/puppet/provider/network_dns/cisco_nexus.rb
@@ -52,7 +52,7 @@ class Puppet::Provider::NetworkDns::CiscoNexus < Puppet::ResourceApi::SimpleProv
     @servers = Cisco::NameServer.nameservers || {}
     @hostname = Cisco::HostName.hostname || {}
 
-    handle_hostname(should[:hostname])
+    handle_hostname(should[:hostname]) if should[:hostname]
     handle_domain(should[:domain]) if should[:domain]
     handle_servers(should[:servers]) if should[:servers]
     handle_searches(should[:search]) if should[:search]

--- a/spec/unit/puppet/provider/network_dns/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/network_dns/cisco_nexus_spec.rb
@@ -81,6 +81,45 @@ RSpec.describe Puppet::Provider::NetworkDns::CiscoNexus do
         provider.update(context, 'settings', should_values)
       end
     end
+    context 'update is called without hostname' do
+      let(:should_values) do
+        {
+          name:     'settings',
+          ensure:   'present',
+          domain:   'foo',
+          search:   ['1.1.1.1'],
+          servers:  ['2.2.2.2'],
+        }
+      end
+
+      it 'performs an update' do
+        expect(Cisco::DomainName).to receive(:new).with('foo')
+        expect(Cisco::HostName).to receive(:new).with('bar').never
+        expect(Cisco::DnsDomain).to receive(:new).with('1.1.1.1')
+        expect(Cisco::NameServer).to receive(:new).with('2.2.2.2')
+        expect(context).to receive(:notice).with(%r{\AUpdating 'settings'})
+        provider.update(context, 'settings', should_values)
+      end
+    end
+    context 'update is called without domain' do
+      let(:should_values) do
+        {
+          name:     'settings',
+          ensure:   'present',
+          search:   ['1.1.1.1'],
+          servers:  ['2.2.2.2'],
+        }
+      end
+
+      it 'performs an update' do
+        expect(Cisco::DomainName).to receive(:new).with('foo').never
+        expect(Cisco::HostName).to receive(:new).with('bar').never
+        expect(Cisco::DnsDomain).to receive(:new).with('1.1.1.1')
+        expect(Cisco::NameServer).to receive(:new).with('2.2.2.2')
+        expect(context).to receive(:notice).with(%r{\AUpdating 'settings'})
+        provider.update(context, 'settings', should_values)
+      end
+    end
   end
 
   describe '#handle_servers' do

--- a/tests/beaker_tests/network_dns/test_network_dns.rb
+++ b/tests/beaker_tests/network_dns/test_network_dns.rb
@@ -48,6 +48,21 @@ tests[:set] = {
   code: [0, 1, 2],
 }
 
+#
+# Set Properties without a hostname to
+# account for a bug that was raised where
+# it would attempt to delete an unmanaged hostname
+#
+tests[:no_hostname] = {
+  desc:           '1.2 Set without hostname',
+  title_pattern:  'settings',
+  manifest_props: {
+    domain: 'foo.bar.com',
+    search: ['test.com'],
+  },
+  code: [0, 1, 2],
+}
+
 def cleanup(original_hostname)
   create_and_apply_test_manifest('network_dns', 'settings', 'hostname', original_hostname)
 end
@@ -60,5 +75,7 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Set Property Testing")
   test_harness_run(tests, :set, skip_idempotence_check: true)
+  cleanup(original_hostname)
+  test_harness_run(tests, :no_hostname, skip_idempotence_check: true)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")


### PR DESCRIPTION
Previously the `hostname` for `network_dns` was trying to be deleted even though it was not present in the manifest. This change will no longer try and manage the hostname if it is not present.