### PR TITLE
(maint) updating utilitylib to reflect the potential hosts changes

### DIFF
--- a/lib/puppet/util/network_device/cisco_nexus/device.rb
+++ b/lib/puppet/util/network_device/cisco_nexus/device.rb
@@ -8,7 +8,7 @@ module Puppet::Util::NetworkDevice::Cisco_nexus # rubocop:disable Style/ClassAnd
       super
       Cisco::Environment.add_env('default',
                                  host:        config['address'],
-                                 port:        config['port'],
+                                 port:        config['port'] ? config['port'].to_i : nil,
                                  transport:   config['transport'],
                                  verify_mode: config['verify_mode'],
                                  username:    config['username'],

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -115,10 +115,11 @@ class Beaker::TestCase
     @device_conf_file = Tempfile.new(['acceptance-device', '.conf'])
 
     @credentials_file.write <<CREDENTIALS
+# the trimming is required due to how beaker-hostgenerator
+# surrounds integers as strings which gets incorrectly
+# parsed
+#{YAML.load(@nexus_host[:device_config].to_json).to_yaml.tr('---', '').tr("'", '')}
 address: "#{beaker_config_connection_address}"
-username: "#{@nexus_host.host_hash[:ssh][:user] || 'admin'}"
-port: "#{@nexus_host.host_hash[:ssh][:port] || '22'}"
-password: "#{@nexus_host.host_hash[:ssh][:password] || 'admin'}"
 CREDENTIALS
     @credentials_file.close
 
@@ -654,16 +655,7 @@ DEVICE
         cmd = PUPPET_BINPATH + "resource cisco_command_config 'interface_cleanup' command='#{cmd}'"
         on(agent, cmd, acceptable_exit_codes: [0, 2])
       else
-        env = {
-          host: beaker_config_connection_address,
-          port: 22,
-          username: @nexus_host[:ssh][:user],
-          password: @nexus_host[:ssh][:password],
-          cookie: nil
-        }
-        Cisco::Environment.add_env('remote', env)
-        test_client = Cisco::Client.create('remote')
-        test_client.set(values: cmd)
+        nxapi_test_set(cmd)
       end
     end
   end
@@ -1113,12 +1105,9 @@ DEVICE
   # Helper method to create nxapi client connection object (agentless)
   def nxapi_test_client
     env = {
-      host: beaker_config_connection_address,
-      port: 22,
-      username: @nexus_host[:ssh][:user],
-      password: @nexus_host[:ssh][:password],
-      cookie: nil
+      host: beaker_config_connection_address
     }
+    env.merge!(@nexus_host[:device_config])
     Cisco::Environment.add_env('remote', env)
     Cisco::Client.create('remote')
   end


### PR DESCRIPTION
Example of the changes to utilitylib if the device_config hash is determined to be the best approach to executing the beaker tests. e.g. using beaker-hostgenerator to generate a hosts file for vmpooler:

```
beaker-hostgenerator 'cisconx-64default.{ssh={user=admin,password=admin},device_config={username=admin,password=admin,port=80,transport=http}' --disable-default-role --global-config disable_updates=false,masterless=true > test.yml
```

Or alternatively adding:

```
device_config:
      username: admin
      password: admin
      port: '80'
      transport: http
```

To existing agentless host files will be enough. 

