### PR TITLE
(FM-7687) simple banner test for agentless communication with puppets…

### DIFF
--- a/spec/unit/puppet/provider/network_dns/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/network_dns/cisco_nexus_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Puppet::Provider::NetworkDns::CiscoNexus do
     context 'update is called without hostname' do
       let(:should_values) do
         {
-          name:     'settings',
-          ensure:   'present',
-          domain:   'foo',
-          search:   ['1.1.1.1'],
-          servers:  ['2.2.2.2'],
+          name:    'settings',
+          ensure:  'present',
+          domain:  'foo',
+          search:  ['1.1.1.1'],
+          servers: ['2.2.2.2'],
         }
       end
 
@@ -104,10 +104,10 @@ RSpec.describe Puppet::Provider::NetworkDns::CiscoNexus do
     context 'update is called without domain' do
       let(:should_values) do
         {
-          name:     'settings',
-          ensure:   'present',
-          search:   ['1.1.1.1'],
-          servers:  ['2.2.2.2'],
+          name:    'settings',
+          ensure:  'present',
+          search:  ['1.1.1.1'],
+          servers: ['2.2.2.2'],
         }
       end
 

--- a/spec/unit/puppet/provider/radius_global/cisco_nexus_spec.rb
+++ b/spec/unit/puppet/provider/radius_global/cisco_nexus_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Puppet::Provider::RadiusGlobal::CiscoNexus do
       }],
     },
     {
-      desc: '`resources` contains unset values and returns default values',
+      desc:      '`resources` contains unset values and returns default values',
       resources: [{
         name:             'default',
         timeout:          'unset',
@@ -233,7 +233,7 @@ RSpec.describe Puppet::Provider::RadiusGlobal::CiscoNexus do
         key:              'unset',
         source_interface: ['unset'],
       }],
-      results: [{
+      results:   [{
         name:             'default',
         timeout:          5,
         retransmit_count: 1,
@@ -242,7 +242,7 @@ RSpec.describe Puppet::Provider::RadiusGlobal::CiscoNexus do
       }],
     },
     {
-      desc: '`resources` contains -1 unset values and returns default values',
+      desc:      '`resources` contains -1 unset values and returns default values',
       resources: [{
         name:             'default',
         timeout:          -1,
@@ -250,7 +250,7 @@ RSpec.describe Puppet::Provider::RadiusGlobal::CiscoNexus do
         key:              'unset',
         source_interface: ['unset'],
       }],
-      results: [{
+      results:   [{
         name:             'default',
         timeout:          5,
         retransmit_count: 1,

--- a/tests/beaker_tests/agentless/test_agentless_pe.rb
+++ b/tests/beaker_tests/agentless/test_agentless_pe.rb
@@ -26,55 +26,39 @@ require File.expand_path('../../lib/utilitylib.rb', __FILE__)
 # Test hash top-level keys
 tests = {
   agent:         agent,
+  proxy_agent:   proxy_agent,
   master:        master,
-  resource_name: 'radius_global',
+  resource_name: 'banner',
   ensurable:     false,
 }
 
 # Skip -ALL- tests if a top-level platform/os key exludes this platform
 skip_unless_supported(tests)
+skip_unless_proxy_agent(tests)
 
 # Test hash test cases
 tests[:default] = {
   desc:           '1.1 Default Properties',
   title_pattern:  'default',
   manifest_props: {
-    timeout:          'unset',
-    retransmit_count: 'unset',
-    key:              'unset',
-    source_interface: ['unset'],
-  },
-  resource:       {
-    timeout:          5,
-    retransmit_count: 1,
-    key:              'unset',
-    source_interface: ['unset'],
+    motd: 'default'
   },
   code:           [0, 2],
 }
 
-# Test hash test cases
+#
+# non_default_properties
+#
 tests[:non_default] = {
-  desc:           '1.1 Non Default Properties',
+  desc:           '2.1 Non Default Properties',
   title_pattern:  'default',
   manifest_props: {
-    timeout:          6,
-    retransmit_count: 2,
-    key:              '55555',
-    source_interface: ['ethernet1/1'],
+    motd: 'Test MOTD banner!'
   },
-  code:           [0, 2],
 }
 
 def cleanup(agent)
-  test_set(agent, 'radius-server timeout 5')
-  test_set(agent, 'radius-server retransmit 1')
-  test_set(agent, 'no ip radius source-interface')
-
-  # To remove a configured key we have ot know the key value
-  test_get(agent, 'include radius | include key')
-  key = stdout.match('^radius-server key (\d+)\s+(.*)') if stdout
-  command_config(agent, "no radius-server key #{key[1]} #{key[2]}", "removing key #{key[2]}") if key
+  test_set(agent, 'no banner motd')
 end
 
 #################################################################
@@ -87,8 +71,9 @@ test_name "TestCase :: #{tests[:resource_name]}" do
   # -------------------------------------------------------------------
   logger.info("\n#{'-' * 60}\nSection 1. Default Property Testing")
   test_harness_run(tests, :default)
+
   # -------------------------------------------------------------------
-  logger.info("\n#{'-' * 60}\nSection 2. Non-Default Property Testing")
+  logger.info("\n#{'-' * 60}\nSection 2. Non Default Property Testing")
   test_harness_run(tests, :non_default)
 end
 logger.info("TestCase :: #{tests[:resource_name]} :: End")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -145,6 +145,12 @@ DEVICE
     end
   end
 
+  # Method to return an proxy_agent
+  # if not already called
+  def proxy_agent
+    find_host_with_role :proxy_agent
+  end
+
   # These methods are defined outside of a module so that
   # they can access the Beaker DSL API's.
 
@@ -237,6 +243,11 @@ DEVICE
   # Full command string for puppet agent
   def puppet_agent_cmd
     PUPPET_BINPATH + 'agent -t --trace'
+  end
+
+  # Full command string for running puppet device on a proxy_agent
+  def puppet_device_cmd
+    PUPPET_BINPATH + "device --target #{beaker_config_connection_address} --trace --debug"
   end
 
   # full command string for puppet resource commands
@@ -334,7 +345,20 @@ DEVICE
         on(tests[:master], tests[id][:manifest])
         code = (tests[id][:code]) ? tests[id][:code] : [2]
         logger.debug("test_manifest :: check puppet agent cmd (code: #{code})")
-        on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: code)
+        if tests[:proxy_agent]
+          # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
+          # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
+          # if !code.include?($?.exitstatus)
+          #  raise 'Errored test'
+          # end
+          on(tests[:proxy_agent], puppet_device_cmd, acceptable_exit_codes: [0, 1, 2])
+          if !(stdout.include? 'Applied catalog') && tests[id][:stderr_pattern].nil?
+            logger.info(stdout)
+            raise 'Errored test as the command result did not match applied catalog'
+          end
+        else
+          on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: code)
+        end
         output = nil
       else
         code = (tests[id][:code]) ? tests[id][:code] : [2]
@@ -389,6 +413,16 @@ DEVICE
       logger.debug('test_idempotence :: BEGIN')
       if tests[:agent]
         on(tests[:agent], puppet_agent_cmd, acceptable_exit_codes: [0])
+      elsif tests[:proxy_agent]
+        # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
+        # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
+        # if !$?.exitstatus == 0
+        #   raise 'Errored idempotence test'
+        # end
+        on(tests[:proxy_agent], puppet_device_cmd, acceptable_exit_codes: [0, 1, 2])
+        if stdout.include? "#{tests[:resource_name]}[#{tests[id][:title_pattern]}]: Updating:"
+          raise 'Errored idempotence test'
+        end
       else
         # system("bundle exec puppet device --verbose --trace --strict=error --modulepath spec/fixtures --target nexus --libdir lib/ --apply apply.pp")
         # See https://tickets.puppetlabs.com/browse/PUP-9067 "`puppet device` should respect --detailed-exitcodes"
@@ -864,6 +898,13 @@ DEVICE
                            #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
                              #{state}\n#{manifest}
                            }\n}\nEOF"
+                           elsif tests[:proxy_agent]
+                             "cat <<EOF >#{PUPPETMASTER_MANIFESTPATH}
+                             \nnode '#{beaker_config_connection_address}' {
+                             #{harness_class.dependency_manifest(self, tests, id)}
+                             #{tests[:resource_name]} { '#{tests[id][:title_pattern]}':
+                               #{state}\n#{manifest}
+                             }\n}\nEOF"
                            else
                              create_agentless_manifest(tests, tests[:resource_name], id, state, manifest, harness_class: harness_class)
                              # logger.debug("Agentless Manifest:\n" + manifest)
@@ -1106,11 +1147,11 @@ DEVICE
   # Helper method to create nxapi client connection object (agentless)
   def nxapi_test_client
     env = {
-      host: beaker_config_connection_address,
-      port: @nexus_host[:ssh][:port] || 80,
+      host:     beaker_config_connection_address,
+      port:     @nexus_host[:ssh][:port] || 80,
       username: @nexus_host[:ssh][:user],
       password: @nexus_host[:ssh][:password],
-      cookie: nil
+      cookie:   nil
     }
     Cisco::Environment.add_env('remote', env)
     Cisco::Client.create('remote')
@@ -1618,6 +1659,17 @@ DEVICE
           '(or test file) is not supported on this node'
     banner = '#' * msg.length
     raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
+  end
+
+  # This is a simple top-level skip similar to what exists in the minitests.
+  # Callers will skip all tests when true.
+  # tests[:proxy_agent] - if the proxy_agent is present
+  # tests[:resource_name] - provider name (e.g. 'cisco_vxlan_vtep')
+  def skip_unless_proxy_agent(tests)
+    msg = "Skipping all tests; '#{tests[:resource_name]}' "\
+        '(or test file) is not supported without a proxy agent'
+    banner = '#' * msg.length
+    raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self) unless proxy_agent
   end
 
   def skipped_tests_summary(tests)

--- a/tests/beaker_tests/network_dns/test_network_dns.rb
+++ b/tests/beaker_tests/network_dns/test_network_dns.rb
@@ -60,7 +60,7 @@ tests[:no_hostname] = {
     domain: 'foo.bar.com',
     search: ['test.com'],
   },
-  code: [0, 1, 2],
+  code:           [0, 1, 2],
 }
 
 def cleanup(original_hostname)


### PR DESCRIPTION
…erver

This is my consideration for executing the tests agentlessly while using a proxy agent and PE/Puppetserver to compile the catalogs. The following files is what I used:

```
---
HOSTS:
  cisconx-64-1:
    pe_dir: 
    pe_ver: 
    pe_upgrade_dir: 
    pe_upgrade_ver: 
    hypervisor: vmpooler
    platform: cisco_nexus-7-x86_64
    packaging_platform: cisco-wrlinux-5-x86_64
    vrf: management
    ssh:
      user: admin
      password: admin
    template: cisco-nxos-9k-x86_64
    roles:
    - default
  centos7-64-1:
    pe_dir: 
    pe_ver: 
    pe_upgrade_dir: 
    pe_upgrade_ver: 
    hypervisor: vmpooler
    platform: el-7-x86_64
    packaging_platform: el-7-x86_64
    template: centos-7-x86_64
    roles:
    - master
    - database
    - dashboard
  centos7-64-2:
    pe_dir: 
    pe_ver: 
    pe_upgrade_dir: 
    pe_upgrade_ver: 
    hypervisor: vmpooler
    platform: el-7-x86_64
    packaging_platform: el-7-x86_64
    template: centos-7-x86_64
    roles:
    - proxy_agent
CONFIG:
  nfs_server: none
  consoleport: 443
  pooling_api: http://vmpooler.delivery.puppetlabs.net/
  disable_updates: false
  masterless: true
```

Which was generated via: `beaker-hostgenerator 'cisconx-64default.{ssh={user=admin,password=admin}-centos7-64mdc-centos7-64proxy_agent.' --disable-default-role --global-config disable_updates=false,masterless=true > test.yml`

Then the test is executed with: 

```
BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2018.1.0
BEAKER_PE_VER=2018.1.0
BEAKER_PUPPET_AGENT_VERSION=5.5.1
SHA=5.5.1 MODULE_URL=https://github.com/puppetlabs/cisco-network-puppet-module.git MODULE_REF=puppet6
export BEAKER_PE_DIR BEAKER_PE_VER BEAKER_PUPPET_AGENT_VERSION SHA MODULE_URL MODULE_REF
bundle exec beaker --color --debug --hosts test.yml --pre-suite tests/beaker_presuite/presuite_deploy.rb --keyfile ~/.ssh/id_rsa-acceptance --tests tests/beaker_tests/agentless/test_agentless_pe.rb
```

This could be added as an additional node in our testing environments as it makes use of the presuite_deploy to sign certs etc. If you want to just execute the test and have already set up the puppetserver/PE master and the proxy agent I done it using the following config:

```
HOSTS:
  itcfwctbsgvvvos.delivery.puppetlabs.net: # change this to address of pe master/puppetserver
    roles:
    - master
    platform: centos-7-x86_64
    ip: itcfwctbsgvvvos.delivery.puppetlabs.net # change this to address of pe master/puppetserver
    ssh:
      auth_methods:
      - publickey
      - password
      user: root
      password:
  fsa3yayle675y8w.delivery.puppetlabs.net: # change this to address of proxy agent
    roles:
    - proxy_agent
    platform: centos-7-x86_64
    ip: fsa3yayle675y8w.delivery.puppetlabs.net # change this to address of proxy agent
    ssh:
      auth_methods:
      - publickey
      - password
      user: root
      password:
  owd2ctu2ij83nt5.delivery.puppetlabs.net: # change this to address of NEXUS VM
    roles:
    - default
    platform: cisco_nexus-9-x86_64
    ip: owd2ctu2ij83nt5.delivery.puppetlabs.net # replace with address of NEXUS VM
    vrf: management
    ssh:
      user: admin
      password: admin
CONFIG:
  nfs_server: none
  disable_updates: false
  masterless: true
```

Then the test can be executed with the following: `BEAKER_provision=no BEAKER_destroy=no bundle exec beaker --hosts ./newtest.cfg --tests tests/beaker_tests/agentless/test_agentless_pe.rb`