### PR TITLE
(maint) removing the ngmvpn feature on vxlan_vtep tests

### DIFF
--- a/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
+++ b/tests/beaker_tests/cisco_vxlan_vtep/test_vxlan_vtep.rb
@@ -90,7 +90,6 @@ tests[:non_default_2] = {
 class TestVxlanVtep < BaseHarness
   def self.test_harness_dependencies(ctx, _tests, _id)
     ctx.test_set(ctx.agent, 'evpn multisite border 150') if ctx.platform[/ex/]
-    ctx.test_set(ctx.agent, 'feature ngmvpn') if ctx.platform[/n9k$/]
 
     return unless ctx.platform[/n(5|6)k/]
     ctx.skip_if_nv_overlay_rejected(ctx.agent)
@@ -127,7 +126,6 @@ end
 #################################################################
 test_name "TestCase :: #{tests[:resource_name]}" do
   teardown do
-    test_set(agent, 'no feature ngmvpn') if platform[/n9k$/]
     test_set(agent, 'no evpn multisite border 150') if platform[/ex/]
     resource_absent_cleanup(agent, 'cisco_vxlan_vtep')
     vdc_limit_f3_no_intf_needed(:clear)


### PR DESCRIPTION
This feature does not appear to work on a fresh 9K VM as it is not configured to allow these features according to: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/9-x/vxlan/configuration/guide/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_9x/b_Cisco_Nexus_9000_Series_NX-OS_VXLAN_Configuration_Guide_9x_chapter_01101.html

Removing this command in order to have the 9K tests back in a passing state.