### PR TITLE
Puppet6 Guestshell Agent Fixes

### DIFF
--- a/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_cfg_svc.rb
@@ -75,9 +75,11 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_cfg_svc) do
           an array of strings, keyword 'default'."
 
     validate do |val|
-      val.split.each do |group|
-        fail "group #{value} must be a String" unless
-          group.kind_of?(String)
+      unless val.kind_of?(Symbol)
+        val.split.each do |group|
+          fail "group #{value} must be a String" unless
+            group.kind_of?(String)
+        end
       end
     end
 

--- a/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
+++ b/lib/puppet/type/cisco_aaa_authorization_login_exec_svc.rb
@@ -75,9 +75,11 @@ Puppet::Type.newtype(:cisco_aaa_authorization_login_exec_svc) do
           an array of strings, keyword 'default'."
 
     validate do |val|
-      val.split.each do |group|
-        fail "group #{value} must be a String" unless
-          group.kind_of?(String)
+      unless val.kind_of?(Symbol)
+        val.split.each do |group|
+          fail "group #{value} must be a String" unless
+            group.kind_of?(String)
+        end
       end
     end
 

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -1174,7 +1174,7 @@ DEVICE
   def test_get(agent, filter, opt=:raw, is_a_running_config_command: true)
     if agent
       cmd_prefix = PUPPET_BINPATH + "resource cisco_command_config 'cc' "
-      on(agent, cmd_prefix + "test_get=\\\"#{filter}\\\"").output
+      on(agent, cmd_prefix + "test_get=\"#{filter}\"").output
       command = stdout
     else
       command = nxapi_test_get(filter, is_a_running_config_command)
@@ -1219,7 +1219,7 @@ DEVICE
   def command_config(agent, cmd, msg='', ignore_errors: false)
     logger.info("\n#{msg}")
     if agent
-      cmd = "resource cisco_command_config 'cc' command=\\\"#{cmd}\\\""
+      cmd = "resource cisco_command_config 'cc' command='#{cmd}'"
       cmd = PUPPET_BINPATH + cmd
       on(agent, cmd, acceptable_exit_codes: [0, 2])
     else

--- a/tests/beaker_tests/radius_global/test_radius_global.rb
+++ b/tests/beaker_tests/radius_global/test_radius_global.rb
@@ -71,14 +71,8 @@ def cleanup(agent)
   test_set(agent, cmds)
 
   # To remove a configured key we have to know the key value
-  out = test_get(agent, "include 'radius-server key'")
-
-  # Clean up cc output for key match; use single quotes to wrap key
-  # e.g. "cisco_command_config { 'cc':\n  test_get => \"\\nradius-server key 7 \\\"55555 42\\\"\\n\",\n}\n"
-  #      "cisco_command_config { 'cc':\n  test_get => \"\\nradius-server key 7 '55555 42'"
-  out.sub!(/\\\"\\n.*/m, "'").sub!(/\\\"/, "'")
-
-  key = out.match('radius-server key (\d+)\s+(.*)') if out
+  test_get(agent, 'include radius | include key')
+  key = stdout.match('^radius-server key (\d+)\s+(.*)') if stdout
   command_config(agent, "no radius-server key #{key[1]} #{key[2]}", "removing key #{key[2]}") if key
 end
 


### PR DESCRIPTION
This PR fixes issues responsible for around 20 beaker test failures.

1. Fixes in aaa types to check for the symbol `:default` so puppet does not error out.
2. Remove backslashes now that they are no longer required with latest beaker version for utilitylib methods `test_get` and `command_config`
3. Revert change in `radius_global` beaker test.  No longer needed with changes to utilitylib.