### PR TITLE
(maint) no longer adding quotes to tacacs server and server host

### DIFF
--- a/tests/beaker_tests/cisco_tacacs_server/test_tacacs_server.rb
+++ b/tests/beaker_tests/cisco_tacacs_server/test_tacacs_server.rb
@@ -68,7 +68,7 @@ tests[:non_default] = {
   resource:       {
     'timeout'             => '50',
     'deadtime'            => '0',
-    'encryption_password' => add_quotes('WXYZ12'),
+    'encryption_password' => 'WXYZ12',
     'encryption_type'     => 'encrypted',
     'directed_request'    => 'false',
     'source_interface'    => 'Ethernet1/4',

--- a/tests/beaker_tests/cisco_tacacs_server_host/test_tacacs_server_host.rb
+++ b/tests/beaker_tests/cisco_tacacs_server_host/test_tacacs_server_host.rb
@@ -62,7 +62,7 @@ tests[:non_default] = {
   resource:       {
     'port'                => '90',
     'timeout'             => '39',
-    'encryption_password' => add_quotes('test123'),
+    'encryption_password' => 'test123',
   },
 }
 


### PR DESCRIPTION
The addition of quotes was causing issues on 9K tests as the quotes were being stripped out and are no longer expected in the returned resource.