### PR TITLE
(maint) catching the proxy_agent exception when testing against an agent

### DIFF
--- a/tests/beaker_presuite/presuite_deploy.rb
+++ b/tests/beaker_presuite/presuite_deploy.rb
@@ -89,7 +89,7 @@ test_name 'Prep Masters & Install Puppet' do
         on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-puppetserver_gem', 'RSAPI'))} >> /root/Puppetfile")
         on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-netdev_stdlib', 'NETDEV_STDLIB'))} >> /root/Puppetfile")
         on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-ciscopuppet', 'MODULE'))} >> /root/Puppetfile")
-        if proxy_agent
+        if proxy_agents
           on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-device_manager', 'DEVICE_MANAGER'))} >> /root/Puppetfile")
           on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-concat', 'CONCAT'))} >> /root/Puppetfile")
           on(node, "echo #{Shellwords.escape(mod_line_from_env('puppetlabs-hocon', 'HOCON'))} >> /root/Puppetfile")

--- a/tests/beaker_tests/lib/utilitylib.rb
+++ b/tests/beaker_tests/lib/utilitylib.rb
@@ -147,8 +147,14 @@ DEVICE
 
   # Method to return an proxy_agent
   # if not already called
+  # Will skip the test if it does not find the
+  # role matching proxy_agent
   def proxy_agent
     find_host_with_role :proxy_agent
+  rescue Beaker::DSL::Outcomes::FailTest
+    msg = 'Skipping test as it is not supported in this mode'
+    banner = '#' * msg.length
+    raise_skip_exception("\n#{banner}\n#{msg}\n#{banner}\n", self)
   end
 
   # These methods are defined outside of a module so that


### PR DESCRIPTION
Due to how beaker works with `masterless` the exception was never thrown, when running with agents against a puppet server beaker would throw the following:

```
Beaker::DSL::Outcomes::FailTest: There should be one host with proxy_agent defined!
```

This change will catch the exception and skip the test as the test that uses proxy_agents will only work with a certain host file configuration