### PR TITLE
use require_relative to avoid windows error

### DIFF
--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -1,5 +1,6 @@
 require 'facter'
-require_relative '../facter/cisco_nexus'
+#require_relative '../facter/cisco_nexus'
+require 'facter/cisco_nexus'
 
 Facter.add(:cisco) do
   confine operatingsystem: [:ios_xr, :nexus]

--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -1,5 +1,5 @@
 require 'facter'
-require 'facter/cisco_nexus'
+require_relative '../facter/cisco_nexus'
 
 Facter.add(:cisco) do
   confine operatingsystem: [:ios_xr, :nexus]

--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -1,6 +1,6 @@
 require 'facter'
-#require_relative '../facter/cisco_nexus'
-require 'facter/cisco_nexus'
+require_relative '../facter/cisco_nexus'
+#require 'facter/cisco_nexus'
 
 Facter.add(:cisco) do
   confine operatingsystem: [:ios_xr, :nexus]

--- a/lib/facter/cisco.rb
+++ b/lib/facter/cisco.rb
@@ -1,6 +1,5 @@
 require 'facter'
 require_relative '../facter/cisco_nexus'
-#require 'facter/cisco_nexus'
 
 Facter.add(:cisco) do
   confine operatingsystem: [:ios_xr, :nexus]


### PR DESCRIPTION
Running facter on the CLI or via "facter_task" task generates an error saying it can't find/resolve reference to cisco_nexus.  Using require_relative fixes this issue.